### PR TITLE
Added information that a given device is connected to a VM

### DIFF
--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -73,7 +73,7 @@ class DomainDecorator(PropertiesDecorator):
         return label
 
 
-def device_hbox(dev: Device) -> Gtk.Box:
+def device_hbox(dev: Device, attached=False) -> Gtk.Box:
     ''' Returns a :class:`Gtk.Box` containing the device name & icon.. '''
     if dev['dev_class'] == 'block':
         icon = 'drive-removable-media'
@@ -85,7 +85,12 @@ def device_hbox(dev: Device) -> Gtk.Box:
         icon = 'emblem-important'
     dev_icon = create_icon(icon)
 
-    name_label = Gtk.Label(dev.name, xalign=0)
+    name_label = Gtk.Label(xalign=0)
+    if attached:
+        name_label.set_markup(
+            '<b>' + dev.name + ' (' + dev.frontend_domain['name'] + ')</b>')
+    else:
+        name_label.set_text(dev.name)
     name_label.set_max_width_chars(64)
     name_label.set_ellipsize(Pango.EllipsizeMode.END)
 

--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -187,13 +187,30 @@ class DeviceItem(Gtk.ImageMenuItem):
         self.dev_class = self.dev["dev_class"]
         label_path = self.dev.backend_domain['label']  # type: dbus.ObjectPath
         vm_icon = LABELS[label_path]["icon"]  # type: Gtk.Image
-        hbox = qui.decorators.device_hbox(self.dev)  # type: Gtk.Box
+        self.hbox = qui.decorators.device_hbox(
+            self.dev,
+            attached=self.dev.frontend_domain is not None)  # type: Gtk.Box
 
         self.set_image(qui.decorators.create_icon(vm_icon))
         self.obj_path = dev_obj_path
-        self.add(hbox)
+        self.add(self.hbox)
         submenu = DomainMenu(self.dev)
         self.set_submenu(submenu)
+
+        self.dev.connect_to_signal('Attached', self.attach)
+        self.dev.connect_to_signal('Detached', self.detach)
+
+    def attach(self, dev_path):
+        self.remove(self.hbox)
+        self.hbox = qui.decorators.device_hbox(self.dev, attached=True)
+        self.add(self.hbox)
+        self.show_all()
+
+    def detach(self, dev_path):
+        self.remove(self.hbox)
+        self.hbox = qui.decorators.device_hbox(self.dev, attached=False)
+        self.add(self.hbox)
+        self.show_all()
 
 
 class DeviceGroups():


### PR DESCRIPTION
When a given device is connected to any VM, the device name is bolded
and the VM name is appended to the device menu item in parentheses.

QubesOS/qubes-issues#3241