### PR TITLE
Fixed qui-domain/qui-device display when in bottom panel

### DIFF
--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -128,11 +128,13 @@ class DomainMenu(Gtk.Menu):
 
         self.insert(menu_item, position)
         self.show_all()
+        self.queue_draw()
 
     def remove_vm(self, _, vm_obj_path):
         menu_item = self.menu_items[vm_obj_path]
         self.remove(menu_item)
         self.show_all()
+        self.queue_draw()
 
     def dev_attached(self, vm_obj_path):
         menu_item = self.menu_items[vm_obj_path]

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -214,6 +214,8 @@ class DomainMenuItem(Gtk.ImageMenuItem):
         if 'label' in changed_properties:
             self.set_image(self.decorator.icon())
 
+        self._set_image(self._state())
+
 class DomainTray(Gtk.Application):
     ''' A tray icon application listing all but halted domains. ” '''
 
@@ -241,6 +243,7 @@ class DomainTray(Gtk.Application):
         vm_widget = self.menu_items[vm_path]
         self.tray_menu.remove(vm_widget)
         del self.menu_items[vm_path]
+        self.tray_menu.queue_draw()
 
     def update_domain_item(self, _, vm_path):
         ''' Add/Replace the menu item with the started menu for the specified vm in the tray'''
@@ -263,6 +266,7 @@ class DomainTray(Gtk.Application):
         self.tray_menu.insert(domain_item, position)
         self.menu_items[vm_path] = domain_item
         self.tray_menu.show_all()
+        self.tray_menu.queue_draw()
 
     def run(self):  # pylint: disable=arguments-differ
         for signal_name, handler_function in self.signal_callbacks.items():


### PR DESCRIPTION
(Hopefully) fixed error in displaying qui-domains/qui-devices menu when
the tray was in bottom panel (no menu resize when a VM was added).
Hopefully, also fixed error in displaying VM state (VM stuck in
"transient/running wheel" state).

fixes QubesOS/qubes-issues#2970