### PR TITLE
Disk Size Widget

### DIFF
--- a/autostart/qui-disk-space.desktop
+++ b/autostart/qui-disk-space.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Icon=drive-harddisk
+Name=Disk Space Tray
+Categories=System;Monitor;
+Exec=python3 -m qui.tray.disk_space
+Terminal=false
+Type=Application

--- a/qui/tray/disk_space.py
+++ b/qui/tray/disk_space.py
@@ -25,7 +25,7 @@ class PoolUsageData:
         self.__populate_pools()
 
     def __populate_pools(self):
-        for pool in self.qubes_app.pools.values():
+        for pool in sorted(self.qubes_app.pools.values()):
             self.pools.append(pool)
             if pool.size == 0:
                 continue
@@ -35,7 +35,6 @@ class PoolUsageData:
                 self.warning_message.append(
                     "\n{:.1%} space left in pool {}".format(
                         1-pool.usage/pool.size, pool.name))
-        self.pools = sorted(self.pools)
 
     def get_pools_widgets(self):
         for p in self.pools:

--- a/qui/tray/disk_space.py
+++ b/qui/tray/disk_space.py
@@ -1,0 +1,194 @@
+# pylint: disable=missing-docstring
+import sys
+
+import gi
+gi.require_version('Gtk', '3.0')  # isort:skip
+from gi.repository import Gtk, GObject  # isort:skip
+
+from qubesadmin import Qubes
+from qubesadmin.utils import size_to_human
+
+# TODO: add configurable warning levels
+WARN_LEVEL = 0.9
+URGENT_WARN_LEVEL = 0.95
+
+
+class PoolUsageData:
+    def __init__(self):
+        self.qubes_app = Qubes()
+
+        self.pools = []
+        self.total_size = 0
+        self.used_size = 0
+        self.warning_message = []
+
+        self.__populate_pools()
+
+    def __populate_pools(self):
+        for pool in self.qubes_app.pools.values():
+            self.pools.append(pool)
+            if pool.size == 0:
+                continue
+            self.total_size += pool.size
+            self.used_size += pool.usage
+            if pool.usage/pool.size >= URGENT_WARN_LEVEL:
+                self.warning_message.append(
+                    "\n{:.1%} space left in pool {}".format(
+                        1-pool.usage/pool.size, pool.name))
+        self.pools = sorted(self.pools)
+
+    def get_pools_widgets(self):
+        for p in self.pools:
+            yield self.__create_box(p)
+
+    def get_warning(self):
+        return self.warning_message
+
+    def get_usage(self):
+        return self.used_size/self.total_size
+
+    def __create_box(self, pool):
+        pool_name = Gtk.Label(xalign=0)
+        percentage_use = Gtk.Label()
+        numeric_use = Gtk.Label()
+
+        if int(pool.size) > 0:
+            # TODO: add checking if pool is not contained in another pool
+            pool_name.set_markup('<b>{}</b>'.format(pool.name))
+
+            percentage = int(pool.usage)/int(pool.size)
+            percentage_use.set_markup(colored_percentage(percentage))
+            percentage_use.set_justify(Gtk.Justification.RIGHT)
+
+            numeric_use.set_markup(
+                '<span color=\'grey\'><i>{}/{}</i></span>'.format(
+                    size_to_human(int(pool.usage)),
+                    size_to_human(int(pool.size))))
+            numeric_use.set_justify(Gtk.Justification.RIGHT)
+
+        else:
+            pool_name.set_markup(
+                '<span color=\'grey\'><i>{}</i></span>'.format(pool.name))
+
+        pool_name.set_margin_left(20)
+
+        return pool_name, percentage_use, numeric_use
+
+
+def colored_percentage(value):
+    if value < WARN_LEVEL:
+        color = 'green'
+    elif value < URGENT_WARN_LEVEL:
+        color = 'orange'
+    else:
+        color = 'red'
+
+    result = '<span color=\'{}\'>{:.1%}</span>'.format(color, value)
+
+    return result
+
+
+class DiskSpace(Gtk.Application):
+    def __init__(self, **properties):
+        super().__init__(**properties)
+
+        self.icon = Gtk.StatusIcon()
+        self.icon.connect('button-press-event', self.make_menu)
+        self.refresh_icon()
+
+        GObject.timeout_add_seconds(120, self.refresh_icon)
+
+        Gtk.main()
+
+    def refresh_icon(self):
+        pool_data = PoolUsageData()
+        warning = pool_data.get_warning()
+
+        if warning:
+            self.icon.set_from_stock(Gtk.STOCK_DIALOG_WARNING)
+            text = "WARNING! You are running out of disk space." + \
+                   ''.join(warning)
+            self.icon.set_tooltip_markup(text)
+        else:
+            self.icon.set_from_stock(Gtk.STOCK_HARDDISK)
+            self.icon.set_tooltip_markup('')
+
+        return True  # needed for Gtk to correctly loop the function
+
+    def make_menu(self, _, event):
+        pool_data = PoolUsageData()
+
+        menu = Gtk.Menu()
+
+        menu.append(self.make_top_box(pool_data))
+
+        title_label = Gtk.Label(xalign=0)
+        title_label.set_markup("<b>Volumes</b>")
+        title_menu_item = Gtk.MenuItem()
+        title_menu_item.add(title_label)
+        title_menu_item.set_sensitive(False)
+        menu.append(title_menu_item)
+
+        grid = Gtk.Grid()
+        col_no = 0
+        for (label1, label2, label3) in pool_data.get_pools_widgets():
+            grid.attach(label1, 0, col_no, 1, 1)
+            grid.attach(label2, 1, col_no, 1, 1)
+            grid.attach(label3, 2, col_no, 1, 1)
+            col_no += 1
+
+        grid.set_column_spacing(20)
+        grid_menu_item = Gtk.MenuItem()
+        grid_menu_item.add(grid)
+        grid_menu_item.set_sensitive(False)
+        menu.append(grid_menu_item)
+
+        menu.set_reserve_toggle_size(False)
+
+        menu.show_all()
+        menu.popup(None,  # parent_menu_shell
+                   None,  # parent_menu_item
+                   None,  # func
+                   None,  # data
+                   event.button,  # button
+                   Gtk.get_current_event_time())  # activate_time
+
+    def make_top_box(self, pool_data):
+        grid = Gtk.Grid()
+
+        name_label = Gtk.Label(xalign=0)
+        name_label.set_markup("<b>Total disk usage</b>")
+
+        percentage_value = Gtk.Label()
+        percentage_value.set_markup(colored_percentage(pool_data.get_usage()))
+        percentage_value.set_margin_top(10)
+
+        progress_bar = Gtk.LevelBar()
+        progress_bar.set_min_value(0)
+        progress_bar.set_max_value(100)
+        progress_bar.set_value(int(pool_data.get_usage()*100))
+        progress_bar.set_vexpand(True)
+        progress_bar.set_hexpand(True)
+        progress_bar.set_margin_left(20)
+        progress_bar.set_margin_right(10)
+        progress_bar.set_margin_top(10)
+
+        grid.attach(name_label, 0, 0, 1, 1)
+        grid.attach(progress_bar, 0, 1, 1, 1)
+        grid.attach(percentage_value, 1, 1, 1, 1)
+
+        progress_bar_item = Gtk.MenuItem()
+        progress_bar_item.add(grid)
+
+        progress_bar_item.set_sensitive(False)
+
+        return progress_bar_item
+
+
+def main():
+    app = DiskSpace()
+    app.run()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/rpm_spec/qubes-desktop-linux-manager.spec
+++ b/rpm_spec/qubes-desktop-linux-manager.spec
@@ -80,6 +80,7 @@ mkdir -p $RPM_BUILD_ROOT/etc/xdg/autostart
 cp autostart/qui-domains.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
 cp autostart/qui-devices.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
 cp autostart/qui-clipboard.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
+cp autostart/qui-disk-space.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
 mkdir -p $RPM_BUILD_ROOT/usr/share/icons/Adwaita/22x22/devices/
 cp icons/22x22/generic-usb.png $RPM_BUILD_ROOT/usr/share/icons/Adwaita/22x22/devices/generic-usb.png
 
@@ -125,11 +126,14 @@ gtk-update-icon-cache %{_datadir}/icons/Adwaita &>/dev/null || :
 %{python3_sitelib}/qui/tray/__init__.py
 %{python3_sitelib}/qui/tray/domains.py
 %{python3_sitelib}/qui/tray/devices.py
+%{python3_sitelib}/qui/tray/disk_space.py
 
 %{_bindir}/qui-ls
 %{_bindir}/qui-domains
 %{_bindir}/qui-devices
+%{_bindir}/qui-disk-space
 /etc/xdg/autostart/qui-domains.desktop
 /etc/xdg/autostart/qui-devices.desktop
-/etc/xdg/autostart/qui-clipboard.desktop
+/etc/xdg/autostart/qui-clipboard.dsizeesktop
+/etc/xdg/autostart/qui-disk-space.desktop
 /usr/share/icons/Adwaita/22x22/devices/generic-usb.png

--- a/rpm_spec/qubes-desktop-linux-manager.spec
+++ b/rpm_spec/qubes-desktop-linux-manager.spec
@@ -134,6 +134,6 @@ gtk-update-icon-cache %{_datadir}/icons/Adwaita &>/dev/null || :
 %{_bindir}/qui-disk-space
 /etc/xdg/autostart/qui-domains.desktop
 /etc/xdg/autostart/qui-devices.desktop
-/etc/xdg/autostart/qui-clipboard.dsizeesktop
+/etc/xdg/autostart/qui-clipboard.desktop
 /etc/xdg/autostart/qui-disk-space.desktop
 /usr/share/icons/Adwaita/22x22/devices/generic-usb.png

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@ setup(name='qui',
               'qui-ls = qui.domains_table:main',
               'qui-domains = qui.tray.domains:main',
               'qui-devices = qui.tray.devices:main',
-              'qui-disk-size = qui.tray.disk_space:main'
+              'qui-disk-space = qui.tray.disk_space:main'
           ]
       })

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='qui',
           'gui_scripts': [
               'qui-ls = qui.domains_table:main',
               'qui-domains = qui.tray.domains:main',
-              'qui-devices = qui.tray.devices:main'
+              'qui-devices = qui.tray.devices:main',
+              'qui-disk-size = qui.tray.disk_space:main'
           ]
       })


### PR DESCRIPTION
Added an auto-starting disk space widget. It warns the user if there's
less than 5% free in any pool. (Further improvements, like configurable
warning threshold, will come).

Depends on https://github.com/QubesOS/qubes-core-admin-client/pull/60
fixes QubesOS/qubes-issues#3240
references QubesOS/qubes-issues#3241