### PR TITLE
Qui domains rewrite

### DIFF
--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -38,36 +38,32 @@ class DomainDecorator(PropertiesDecorator):
     # pylint: disable=missing-docstring
     def __init__(self, vm: qubesadmin.vm.QubesVM, margins=(5, 5)) -> None:
         super(DomainDecorator, self).__init__(vm, margins)
+        self.vm = vm
 
     def name(self):
-        label = Gtk.Label(self.obj['name'], xalign=0)
+        label = Gtk.Label(self.vm.name, xalign=0)
         self.set_margins(label)
         return label
 
-    def memory(self) -> Gtk.Label:
+    def memory(self, memory=0) -> Gtk.Label:
         label = Gtk.Label(
-            str(int(self.obj['memory_usage'] / 1024)) + ' MB', xalign=0)
+            str(int(memory / 1024)) + ' MB', xalign=0)  # TODO: fixme
         self.set_margins(label)
         label.set_sensitive(False)
         return label
 
-    def icon(self) -> Gtk.Image:
+    def icon(self) -> Gtk.Image: # TODO: is this working?
         ''' Returns a `Gtk.Image` containing the colored lock icon '''
-        label_path = self.obj['label']
-        assert label_path in LABELS.children
-        label = LABELS.children[label_path]
-        if label is None:
-            label = LABELS.BLACK  # pylint: disable=no-member
-        icon_vm = Gtk.IconTheme.get_default().load_icon(label['icon'], 16, 0)
+        icon_vm = Gtk.IconTheme.get_default().load_icon(self.vm.label.icon, 16, 0)
         icon_img = Gtk.Image.new_from_pixbuf(icon_vm)
         return icon_img
 
-    def netvm(self) -> Gtk.Label:
-        netvm = self.obj['netvm']
+    def netvm(self) -> Gtk.Label:  # TODO: Wot is this?
+        netvm = self.vm.netvm
         if netvm is None:
             label = Gtk.Label('No', xalign=0)
         else:
-            label = Gtk.Label(netvm['name'], xalign=0)
+            label = Gtk.Label(netvm.name, xalign=0)
 
         self.set_margins(label)
         return label

--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -9,10 +9,7 @@ gi.require_version('Gtk', '3.0')  # isort:skip
 from gi.repository import Gtk, Pango  # isort:skip
 
 import qubesadmin
-import qui.models.qubes
 from qui.models.qubes import Device, Domain
-
-LABELS = qui.models.qubes.LabelsManager()
 
 
 class PropertiesDecorator():
@@ -47,18 +44,18 @@ class DomainDecorator(PropertiesDecorator):
 
     def memory(self, memory=0) -> Gtk.Label:
         label = Gtk.Label(
-            str(int(memory / 1024)) + ' MB', xalign=0)  # TODO: fixme
+            str(int(memory / 1024)) + ' MB', xalign=0)
         self.set_margins(label)
         label.set_sensitive(False)
         return label
 
-    def icon(self) -> Gtk.Image: # TODO: is this working?
+    def icon(self) -> Gtk.Image:
         ''' Returns a `Gtk.Image` containing the colored lock icon '''
         icon_vm = Gtk.IconTheme.get_default().load_icon(self.vm.label.icon, 16, 0)
         icon_img = Gtk.Image.new_from_pixbuf(icon_vm)
         return icon_img
 
-    def netvm(self) -> Gtk.Label:  # TODO: Wot is this?
+    def netvm(self) -> Gtk.Label:
         netvm = self.vm.netvm
         if netvm is None:
             label = Gtk.Label('No', xalign=0)

--- a/qui/tests/tests_domains.py
+++ b/qui/tests/tests_domains.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python3
+#
+# The Qubes OS Project, https://www.qubes-os.org/
+#
+# Copyright (C) 2017 boring-stuff <boring-stuff@users.noreply.github.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+#
+import unittest
+import time
+from gi.repository import Gtk
+import qui.tray.domains as domains_widget
+from qubesadmin import Qubes
+
+class DomainsWidgetTest(unittest.TestCase):
+
+    def setUp(self):
+        super(DomainsWidgetTest, self).setUp()
+
+        self.widget = domains_widget.DomainTray('org.qubes.ui.tray.Domains')
+        self.widget.initialize_menu()
+
+        self.qapp = Qubes()
+
+    def tearDown(self):
+        del self.qapp
+        del self.widget
+        super(DomainsWidgetTest, self).tearDown()
+
+    def test_00_icon_loads(self):
+        self.assertGreater(len(self.widget.tray_menu), 0, "Tray menu is empty!")
+
+    def test_01_correct_vm_state(self):
+        # are all running VMs listed
+        domains_in_widget = []
+        for menu_item in self.widget.tray_menu:
+            domain = self.qapp.domains[menu_item.vm['name']]
+            domains_in_widget.append(domain)
+            self.assertTrue(domain.is_running(),
+                            "halted domain listed incorrectly")
+        for domain in self.qapp.domains:
+            if domain.klass != 'AdminVM':
+                self.assertEqual(domain in domains_in_widget,
+                                 domain.is_running(),
+                                 "domain missing from list")
+
+    def test_02_stop_vm(self):
+        domain_to_stop = self.qapp.domains['test-running']
+
+        if not domain_to_stop.is_running():
+            domain_to_stop.start()
+            while domain_to_stop.get_power_state() != 'Running':
+                    time.sleep(1)
+            time.sleep(10)
+
+        menu_item = self.__find_menu_item(domain_to_stop)
+        self.assertIsNotNone(menu_item, "running item incorrectly not listed")
+
+        domain_to_stop.shutdown()
+
+        countdown = 100
+
+        while domain_to_stop.get_power_state() != 'Halted' and countdown > 0:
+            time.sleep(1)
+            countdown -= 1
+
+        self.__refresh_gui(20)
+
+        menu_item = self.__find_menu_item(domain_to_stop)
+        self.assertIsNone(menu_item, "stopped item still incorrectly listed")
+
+    def test_03_start_vm(self):
+        domain_to_start = self.qapp.domains['test-halted']
+
+        if domain_to_start.is_running():
+            domain_to_start.shutdown()
+            while domain_to_start.get_power_state() != 'Halted':
+                time.sleep(1)
+            time.sleep(10)
+
+        # check if selected domain is correctly not listed
+        item = self.__find_menu_item(domain_to_start)
+        self.assertIsNone(item, "domain incorrectly listed as running")
+
+        # start domain
+        domain_to_start.start()
+
+        # should finish starting
+        countdown = 100
+        while countdown > 0:
+            if domain_to_start.get_power_state() == 'Running':
+                self.__refresh_gui(45)
+                item = self.__find_menu_item(domain_to_start)
+                self.assertIsNotNone(item,
+                                     "domain not listed as started")
+                self.assertIsNotNone(item, "item incorrectly not listed")
+                self.assertIsInstance(item.get_submenu(),
+                                      domains_widget.StartedMenu,
+                                      "incorrect menu (debug not start)")
+                break
+            time.sleep(1)
+            countdown -= 1
+
+        domain_to_start.shutdown()
+
+    def __find_menu_item(self, vm):
+        for menu_item in self.widget.tray_menu:
+            menu_domain = self.qapp.domains[menu_item.vm['name']]
+            if menu_domain == vm:
+                return menu_item
+        return None
+
+    @staticmethod
+    def __refresh_gui(delay=0):
+        time.sleep(delay)
+        while Gtk.events_pending():
+                Gtk.main_iteration_do(blocking=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -189,10 +189,6 @@ class DomainMenuItem(Gtk.ImageMenuItem):
     def _set_submenu(self, state):
         if state == 'Running':
             submenu = StartedMenu(self.vm)
-        elif state == 'Crashed':
-            submenu = DebugMenu(self.vm)
-            remove = Gtk.MenuItem("Remove")
-            remove.connect('activate', lambda: self.hide)
         else:
             submenu = DebugMenu(self.vm)
         # This is a workaround for a bug in Gtk which occurs when a
@@ -229,7 +225,6 @@ class DomainTray(Gtk.Application):
 
     def __init__(self, app_name, qapp, dispatcher, stats_dispatcher):
         super().__init__()
-        self.name = app_name
         self.qapp = qapp
         self.dispatcher = dispatcher
         self.stats_dispatcher = stats_dispatcher
@@ -245,7 +240,7 @@ class DomainTray(Gtk.Application):
         self.menu_items = {}
 
         self.register_events()
-        self.set_application_id('org.Qubes.qui.domains')
+        self.set_application_id(app_name)
         self.register()  # register Gtk Application
 
     def register_events(self):
@@ -361,7 +356,7 @@ def main():
     stats_dispatcher = qubesadmin.events.EventsDispatcher(
         qapp, api_method='admin.vm.Stats')
     app = DomainTray(
-        'org.qubes.ui.tray.Domains', qapp, dispatcher, stats_dispatcher)
+        'org.qubes.qui.tray.Domains', qapp, dispatcher, stats_dispatcher)
     app.run()
 
     loop = asyncio.get_event_loop()

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -349,7 +349,7 @@ def main():
     ]
 
     done, _ = loop.run_until_complete(asyncio.wait(
-        tasks, return_when=asyncio.FIRST_EXCEPTION))
+        tasks, return_when=asyncio.ALL_COMPLETED))
 
 
 if __name__ == '__main__':

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -97,6 +97,24 @@ class LogItem(Gtk.ImageMenuItem):
         subprocess.Popen(['qubes-log-viewer', self.path])
 
 
+class RunTerminalItem(Gtk.ImageMenuItem):
+    ''' Run Terminal menu Item. When activated runs a terminal emulator. '''
+    def __init__(self, vm):
+        super().__init__()
+        self.vm = vm
+        icon = Gtk.IconTheme.get_default().load_icon('utilities-terminal', 16,
+                                                     0)
+        image = Gtk.Image.new_from_pixbuf(icon)
+
+        self.set_image(image)
+        self.set_label('Run Terminal')
+
+        self.connect('activate', self.run_terminal)
+
+    def run_terminal(self, _item):
+        self.vm.RunService('qubes.StartApp+qubes-run-terminal')
+
+
 class StartedMenu(Gtk.Menu):
     ''' The sub-menu for a started domain'''
 
@@ -106,9 +124,11 @@ class StartedMenu(Gtk.Menu):
 
         preferences = PreferencesItem(self.vm)
         shutdown_item = ShutdownItem(self.vm)
+        runterminal_item = RunTerminalItem(self.vm)
 
         self.add(preferences)
         self.add(shutdown_item)
+        self.add(runterminal_item)
 
 
 class DebugMenu(Gtk.Menu):

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -200,11 +200,13 @@ class DomainMenuItem(Gtk.ImageMenuItem):
         self.set_submenu(submenu)
 
     def show_spinner(self):
+        self.spinner.start()
         self.spinner.set_no_show_all(False)
         self.spinner.show()
         self.show_all()
 
     def hide_spinner(self):
+        self.spinner.stop()
         self.spinner.set_no_show_all(True)
         self.spinner.hide()
 

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -293,7 +293,7 @@ class DomainTray(Gtk.Application):
             notification.set_body('Domain {} has halted.'.format(vm.name))
         else:
             return
-        self.send_notification('', notification)
+        self.send_notification(None, notification)
 
     def add_domain_item(self, vm, event, **kwargs):
         # check if it already exists

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -113,7 +113,7 @@ class RunTerminalItem(Gtk.ImageMenuItem):
         self.connect('activate', self.run_terminal)
 
     def run_terminal(self, _item):
-        self.vm.RunService('qubes.StartApp+qubes-run-terminal')
+        self.vm.run_service('qubes.StartApp+qubes-run-terminal')
 
 
 class StartedMenu(Gtk.Menu):

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -217,6 +217,8 @@ class DomainTray(Gtk.Application):
         self.widget_icon = Gtk.StatusIcon()
         self.widget_icon.set_from_icon_name('qubes-logo-icon')
         self.widget_icon.connect('button-press-event', self.show_menu)
+        self.widget_icon.set_tooltip_markup(
+            '<b>Qubes Domains</b>\nView and manage running domains.')
 
         self.tray_menu = Gtk.Menu()
 


### PR DESCRIPTION
Qui-domains rewritten to use qubesadmin API.
Hopefully it will squash the persistent bug with stuck spinner on domains. Also includes tests
and a bunch of fixes to not-working features such as log display.
fixes QubesOS/qubes-issues#4000
fixes QubesOS/qubes-issues#3410
fixes QubesOS/qubes-issues#2970
