### PR TITLE
Standardized notification methods in qui-* modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # How to run:
 
-- Install `qubes-dbus` package
-- Make sure `qubes-dbus-proxy` is running 
 - Execute`qui-domains` in a shell.

--- a/TODOs.org
+++ b/TODOs.org
@@ -3,6 +3,6 @@
 - [X] Only show running VMs
 - [X] Do not show dom0
 - [ ] Align the columns of the rows
-- [ ] Do not use D-Bus for querying domain properties. Reasons:
+- [X] Do not use D-Bus for querying domain properties. Reasons:
   + qubeasadmin API is a better abstraction
   + The current implementation is to slow

--- a/rpm_spec/qubes-desktop-linux-manager.spec
+++ b/rpm_spec/qubes-desktop-linux-manager.spec
@@ -47,7 +47,6 @@ BuildArch: noarch
 BuildRequires:  python3-devel
 
 Requires:  python3-setuptools
-Requires:  python3-dbus
 Requires:  python3-gbulb
 Requires:  libappindicator-gtk3
 Requires:  python3-systemd


### PR DESCRIPTION
Now all apps (qui-domains, qui-disk-space, qui-devices and clipboard
notifications) use the same notification mechanism (Gio.Notification
via a Gtk.Application), for less pain in maintenance and also final
removal of the dependency on dbus.