### PR TITLE
Gui agent for performing and notifying user about updates

### DIFF
--- a/autostart/qui-updates.desktop
+++ b/autostart/qui-updates.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Icon=qubes
+Name=Updates Tray
+Categories=System;Monitor;
+Exec=python3 -mqui.tray.updates
+Terminal=false
+Type=Application

--- a/qubes-update-gui.desktop
+++ b/qubes-update-gui.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Exec=qubes-update-gui
+Icon=qubes-manager
+Terminal=false
+Name=Qubes Update
+GenericName=Qubes Update
+StartupNotify=false
+Categories=System;

--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# pylint: disable=wrong-import-position,import-error
+''' A widget that monitors update availability and notifies the user
+ about new updates to templates and standalone VMs'''
+import asyncio
+import sys
+import traceback
+import subprocess
+
+import qubesadmin
+import qubesadmin.events
+
+import gi  # isort:skip
+gi.require_version('Gtk', '3.0')  # isort:skip
+from gi.repository import Gtk, Gio  # isort:skip
+
+import gbulb
+gbulb.install()
+
+
+class UpdatesTray(Gtk.Application):
+    def __init__(self, app_name, qapp, dispatcher):
+        super(UpdatesTray, self).__init__()
+        self.name = app_name
+
+        self.dispatcher = dispatcher
+        self.qapp = qapp
+
+        self.set_application_id(self.name)
+        self.register()  # register Gtk Application
+
+        self.widget_icon = Gtk.StatusIcon()
+        self.widget_icon.set_from_icon_name('software-update-available')
+        self.widget_icon.set_visible(False)
+        self.widget_icon.connect('button-press-event', self.launch_updater)
+        self.widget_icon.set_tooltip_markup(
+            '<b>Qubes Update</b>\nUpdates are available.')
+
+        self.vms_needing_update = set()
+
+    def run(self):  # pylint: disable=arguments-differ
+        self.check_vms_needing_update()
+        self.connect_events()
+
+        self.update_indicator_state()
+
+    @staticmethod
+    def launch_updater(*_args, **_kwargs):
+        subprocess.Popen(['qubes-update-gui'])
+
+    def check_vms_needing_update(self):
+        self.vms_needing_update.clear()
+        for vm in self.qapp.domains:
+            if vm.features.get('updates-available', False):
+                self.vms_needing_update.add(vm.name)
+
+    def connect_events(self):
+        self.dispatcher.add_handler('domain-feature-set:updates-available',
+                                    self.feature_set)
+        self.dispatcher.add_handler('domain-feature-delete:updates-available',
+                                    self.feature_unset)
+
+    def feature_unset(self, vm, event, feature, **_kwargs):
+        # pylint: disable=unused-argument
+        if vm in self.vms_needing_update:
+            self.vms_needing_update.remove(vm)
+            self.update_indicator_state()
+
+    def feature_set(self, vm, event, feature, value, **_kwargs):
+        # pylint: disable=unused-argument
+        if value and vm not in self.vms_needing_update:
+            self.vms_needing_update.add(vm)
+
+            notification = Gio.Notification.new(
+                "New updates are available for {}".format(vm.name))
+            notification.set_priority(Gio.NotificationPriority.NORMAL)
+            self.send_notification(None, notification)
+        elif not value and vm in self.vms_needing_update:
+            self.vms_needing_update.remove(vm)
+
+        self.update_indicator_state()
+
+    def update_indicator_state(self):
+        if self.vms_needing_update:
+            self.widget_icon.set_visible(True)
+        else:
+            self.widget_icon.set_visible(False)
+
+
+def main():
+    qapp = qubesadmin.Qubes()
+    dispatcher = qubesadmin.events.EventsDispatcher(qapp)
+    app = UpdatesTray(
+        'org.qubes.qui.tray.Updates', qapp, dispatcher)
+    app.run()
+
+    loop = asyncio.get_event_loop()
+
+    done, _ = loop.run_until_complete(asyncio.ensure_future(
+        dispatcher.listen_for_events()))
+
+    for d in done:  # pylint: disable=invalid-name
+        try:
+            d.result()
+        except Exception:  # pylint: disable=broad-except
+            exc_type, exc_value = sys.exc_info()[:2]
+            dialog = Gtk.MessageDialog(
+                None, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK)
+            dialog.set_title("Houston, we have a problem...")
+            dialog.set_markup(
+                "<b>Whoops. A critical error in Updates Widget has occured.</b>"
+                " This is most likely a bug in the widget. To restart the "
+                "widget, run 'qui-updates' in dom0.")
+            dialog.format_secondary_markup(
+                "\n<b>{}</b>: {}\n{}".format(
+                   exc_type.__name__, exc_value, traceback.format_exc(limit=10)
+                ))
+            dialog.run()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/qui/updater.glade
+++ b/qui/updater.glade
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.4 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkWindow" id="main_window">
+    <property name="can_focus">False</property>
+    <property name="hexpand">True</property>
+    <property name="vexpand">False</property>
+    <property name="resizable">False</property>
+    <child>
+      <object class="GtkGrid">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">20</property>
+        <property name="margin_right">20</property>
+        <property name="margin_top">20</property>
+        <property name="margin_bottom">20</property>
+        <property name="hexpand">True</property>
+        <property name="row_spacing">20</property>
+        <property name="column_spacing">20</property>
+        <property name="column_homogeneous">True</property>
+        <child>
+          <object class="GtkButton" id="button_next">
+            <property name="label" translatable="yes">Next</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">end</property>
+          </object>
+          <packing>
+            <property name="left_attach">3</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStack" id="main_stack">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">start</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkBox" id="list_page">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">20</property>
+                <property name="margin_bottom">20</property>
+                <property name="vexpand">True</property>
+                <property name="orientation">vertical</property>
+                <property name="baseline_position">top</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
+                    <property name="margin_bottom">20</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="label" translatable="yes">Select templates and qubes to update:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkListBox" id="vm_list">
+                    <property name="height_request">400</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_bottom">20</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="selection_mode">none</property>
+                    <style>
+                      <class name="black-border"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">page_vmlist</property>
+                <property name="title" translatable="yes">Qube list</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="progress_page">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Update progress:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkListBox" id="progress_listview">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="selection_mode">none</property>
+                    <style>
+                      <class name="black-border"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkEventBox" id="details_icon_events">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkImage" id="details_icon">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">pan-end-symbolic</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEventBox" id="details_label_events">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel" id="details_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Details</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow" id="progress_scrolled_window">
+                    <property name="height_request">340</property>
+                    <property name="can_focus">True</property>
+                    <child>
+                      <object class="GtkTextView" id="progress_textview">
+                        <property name="height_request">300</property>
+                        <property name="can_focus">True</property>
+                        <property name="margin_top">20</property>
+                        <property name="margin_bottom">20</property>
+                        <property name="hexpand">True</property>
+                        <property name="hscroll_policy">natural</property>
+                        <property name="vscroll_policy">natural</property>
+                        <property name="editable">False</property>
+                        <property name="justification">fill</property>
+                        <property name="cursor_visible">False</property>
+                        <property name="accepts_tab">False</property>
+                        <property name="monospace">True</property>
+                        <style>
+                          <class name="black-border"/>
+                        </style>
+                      </object>
+                    </child>
+                    <style>
+                      <class name="black-border"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">page0</property>
+                <property name="title" translatable="yes">page0</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+            <property name="width">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button_cancel">
+            <property name="label" translatable="yes">Cancel</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">end</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/qui/updater.glade
+++ b/qui/updater.glade
@@ -11,10 +11,10 @@
       <object class="GtkGrid">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">20</property>
-        <property name="margin_right">20</property>
-        <property name="margin_top">20</property>
-        <property name="margin_bottom">20</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
         <property name="hexpand">True</property>
         <property name="row_spacing">20</property>
         <property name="column_spacing">20</property>
@@ -43,8 +43,6 @@
               <object class="GtkBox" id="list_page">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_top">20</property>
-                <property name="margin_bottom">20</property>
                 <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
                 <property name="baseline_position">top</property>
@@ -54,9 +52,8 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
-                    <property name="margin_bottom">20</property>
+                    <property name="margin_bottom">10</property>
                     <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
                     <property name="label" translatable="yes">Select templates and qubes to update:</property>
                   </object>
                   <packing>
@@ -70,7 +67,6 @@
                     <property name="height_request">400</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_bottom">20</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
                     <property name="selection_mode">none</property>
@@ -210,12 +206,6 @@
                 <property name="position">1</property>
               </packing>
             </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -243,6 +233,9 @@
           <placeholder/>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/qui/updater.py
+++ b/qui/updater.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# pylint: disable=wrong-import-position,import-error
+
+import re
+import time
+import threading
+import subprocess
+import gi  # isort:skip
+gi.require_version('Gtk', '3.0')  # isort:skip
+from gi.repository import Gtk, Gdk, GObject  # isort:skip
+from qubesadmin import Qubes
+
+
+class QubesUpdater(Gtk.Application):
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, qapp):
+        super(QubesUpdater, self).__init__()
+
+        self.qapp = qapp
+
+        self.builder = Gtk.Builder()
+        self.builder.add_from_file('updater.glade')
+
+        self.main_window = self.builder.get_object("main_window")
+
+        self.vm_list = self.builder.get_object("vm_list")
+        self.populate_vm_list()
+
+        self.next_button = self.builder.get_object("button_next")
+        self.next_button.connect("clicked", self.next_clicked)
+
+        self.cancel_button = self.builder.get_object("button_cancel")
+        self.cancel_button.connect("clicked", self.cancel_updates)
+        self.main_window.connect("destroy", self.exit_updater)
+
+        self.stack = self.builder.get_object("main_stack")
+        self.list_page = self.builder.get_object("list_page")
+        self.progress_page = self.builder.get_object("progress_page")
+        self.finish_page = self.builder.get_object("finish_page")
+        self.progress_textview = self.builder.get_object("progress_textview")
+        self.progress_scrolled_window = self.builder.get_object(
+            "progress_scrolled_window")
+        self.progress_listview = self.builder.get_object("progress_listview")
+
+        self.details_visible = True
+        self.details_icon = self.builder.get_object("details_icon")
+        self.builder.get_object("details_icon_events").connect(
+            "button-press-event", self.toggle_details)
+        self.builder.get_object("details_label_events").connect(
+            "button-press-event", self.toggle_details)
+
+        self.load_css()
+
+        self.main_window.show_all()
+        self.toggle_details()
+
+        self.update_thread = None
+        self.exit_triggered = False
+
+        Gtk.main()
+
+    @staticmethod
+    def load_css():
+        style_provider = Gtk.CssProvider()
+        css = b'''
+        .black-border { 
+            border-width: 1px; 
+            border-color: #c6c6c6; 
+            border-style: solid;
+        }
+        '''
+        style_provider.load_from_data(css)
+
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(),
+            style_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+    def populate_vm_list(self):
+        for vm in self.qapp.domains:
+            if vm.klass == 'AdminVM':
+                self.vm_list.add(VMListBoxRow(
+                    vm, vm.features.get('updates-available', False)))
+
+        for vm in self.qapp.domains:
+            if getattr(vm, 'updateable', False):
+                self.vm_list.add(VMListBoxRow(
+                    vm, vm.features.get('updates-available', False)))
+
+        self.vm_list.connect("row-activated", self.toggle_row_selection)
+
+    def toggle_row_selection(self, _emitter, row):
+        if row:
+            row.checkbox.set_active(not row.checkbox.get_active())
+            row.set_label_text()
+        for vm_row in self.vm_list:
+            if vm_row.checkbox.get_active():
+                self.next_button.set_sensitive(True)
+                return
+            self.next_button.set_sensitive(False)
+
+    def next_clicked(self, _emitter):
+        if self.stack.get_visible_child() == self.list_page:
+            self.stack.set_visible_child(self.progress_page)
+
+            for row in self.vm_list:
+                if row.checkbox.get_active():
+                    self.progress_listview.add(ProgressListBoxRow(row.vm))
+
+            self.progress_listview.show_all()
+
+            self.next_button.set_sensitive(False)
+            self.next_button.set_label("Finish")
+
+            self.update_thread = threading.Thread(target=self.perform_update)
+            self.update_thread.start()
+
+        elif self.stack.get_visible_child() == self.progress_page:
+            self.exit_updater()
+            return
+
+    def toggle_details(self, *_args, **_kwargs):
+        self.details_visible = not self.details_visible
+        self.progress_textview.set_visible(self.details_visible)
+
+        if self.details_visible:
+            self.progress_textview.show()
+            self.progress_scrolled_window.show()
+        else:
+            self.progress_textview.hide()
+            self.progress_scrolled_window.hide()
+
+        if self.details_visible:
+            self.details_icon.set_from_icon_name("pan-down-symbolic",
+                                                 Gtk.IconSize.BUTTON)
+        else:
+            self.details_icon.set_from_icon_name("pan-end-symbolic",
+                                                 Gtk.IconSize.BUTTON)
+
+    def append_text_view(self, text):
+        buffer = self.progress_textview.get_buffer()
+        buffer.insert(buffer.get_end_iter(), text + '\n')
+
+    def perform_update(self):
+        for row in self.progress_listview:
+            if self.exit_triggered:
+                GObject.idle_add(row.set_status, 'failure')
+                GObject.idle_add(
+                    self.append_text_view,
+                    "Cancelled update for {}\n".format(row.vm.name))
+                continue
+
+            GObject.idle_add(
+                self.append_text_view, "Updating {}\n".format(row.vm.name))
+            GObject.idle_add(row.set_status, 'in-progress')
+
+            try:
+                if row.vm.klass == 'AdminVM':
+                    output = subprocess.check_output(
+                        ['sudo', 'qubesctl', '--dom0-only', '--no-color',
+                         'pkg.upgrade', 'refresh=True'],
+                        stderr=subprocess.STDOUT).decode()
+                    ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]')
+                    output = ansi_escape.sub('', output)
+                else:
+                    output = subprocess.check_output(
+                        ['sudo', 'qubesctl', '--skip-dom0',
+                         '--targets=' + row.vm.name, '--show-output',
+                         'pkg.upgrade', 'refresh=True'],
+                        stderr=subprocess.STDOUT).decode()
+
+                GObject.idle_add(self.append_text_view, output)
+                GObject.idle_add(row.set_status, 'success')
+
+            except subprocess.CalledProcessError as ex:
+                GObject.idle_add(
+                    self.append_text_view,
+                    "Error on updating {}: {}\n{}".format(
+                        row.vm.name, str(ex), ex.output))
+                GObject.idle_add(row.set_status, 'failure')
+
+        GObject.idle_add(self.next_button.set_sensitive, True)
+        GObject.idle_add(self.cancel_button.set_visible, False)
+
+    def cancel_updates(self, *_args, **_kwargs):
+        if self.update_thread and self.update_thread.is_alive():
+            self.exit_triggered = True
+            dialog = Gtk.MessageDialog(
+                self.main_window, Gtk.DialogFlags.MODAL, Gtk.MessageType.OTHER,
+                Gtk.ButtonsType.NONE, "Cancelling remaining updates...")
+            dialog.show()
+            while self.update_thread.is_alive():
+                while Gtk.events_pending():
+                    Gtk.main_iteration()
+                time.sleep(1)
+            dialog.hide()
+
+    @staticmethod
+    def exit_updater(_emitter=None):
+        Gtk.main_quit()
+
+
+def get_domain_icon(vm):
+    icon_vm = Gtk.IconTheme.get_default().load_icon(vm.label.icon, 16, 0)
+    icon_img = Gtk.Image.new_from_pixbuf(icon_vm)
+    return icon_img
+
+
+class VMListBoxRow(Gtk.ListBoxRow):
+    def __init__(self, vm, updates_available, **properties):
+        super().__init__(**properties)
+        self.vm = vm
+
+        hbox = Gtk.HBox(orientation=Gtk.Orientation.HORIZONTAL)
+
+        self.label_text = vm.name
+        if updates_available:
+            self.label_text = self.label_text + " (updates available)"
+        self.label = Gtk.Label()
+        self.icon = get_domain_icon(self.vm)
+
+        self.checkbox = Gtk.CheckButton()
+        self.checkbox.set_active(updates_available)
+        self.checkbox.set_margin_right(10)
+
+        self.set_label_text()
+
+        hbox.pack_start(self.checkbox, False, False, 0)
+        hbox.pack_start(self.icon, False, False, 0)
+        hbox.pack_start(self.label, False, False, 0)
+
+        self.add(hbox)
+
+    def set_label_text(self):
+        if self.checkbox.get_active():
+            self.label.set_markup("<b>{}</b>".format(self.label_text))
+        else:
+            self.label.set_markup(self.label_text)
+
+
+class ProgressListBoxRow(Gtk.ListBoxRow):
+    def __init__(self, vm):
+        super(ProgressListBoxRow, self).__init__()
+
+        self.vm = vm
+
+        hbox = Gtk.HBox(orientation=Gtk.Orientation.HORIZONTAL)
+
+        self.icon = get_domain_icon(self.vm)
+        self.icon.set_margin_right(10)
+
+        self.label = Gtk.Label(vm.name)
+        self.label.set_margin_right(10)
+
+        self.progress_box = Gtk.HBox(orientation=Gtk.Orientation.HORIZONTAL)
+
+        hbox.pack_start(self.icon, False, False, 0)
+        hbox.pack_start(self.label, False, False, 0)
+        hbox.pack_start(self.progress_box, False, False, 0)
+
+        self.set_status('not-started')
+        self.add(hbox)
+
+    def set_status(self, status):
+
+        if status == 'not-started':
+            widget = Gtk.Spinner()
+        elif status == 'in-progress':
+            widget = Gtk.Spinner()
+            widget.start()
+        elif status == 'success':
+            widget = Gtk.Image.new_from_icon_name("gtk-apply",
+                                                  Gtk.IconSize.BUTTON)
+        elif status == 'failure':
+            widget = Gtk.Image.new_from_icon_name("gtk-cancel",
+                                                  Gtk.IconSize.BUTTON)
+        else:
+            raise ValueError("unknown status {}".format(status))
+
+        for child in self.progress_box.get_children():
+            self.progress_box.remove(child)
+
+        self.progress_box.pack_start(widget, False, False, 0)
+
+        widget.show()
+
+
+def main():
+    qapp = Qubes()
+    app = QubesUpdater(qapp)
+    app.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/rpm_spec/qubes-desktop-linux-manager.spec
+++ b/rpm_spec/qubes-desktop-linux-manager.spec
@@ -79,8 +79,11 @@ cp autostart/qui-domains.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
 cp autostart/qui-devices.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
 cp autostart/qui-clipboard.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
 cp autostart/qui-disk-space.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
+cp autostart/qui-updates.desktop $RPM_BUILD_ROOT/etc/xdg/autostart
 mkdir -p $RPM_BUILD_ROOT/usr/share/icons/Adwaita/22x22/devices/
 cp icons/22x22/generic-usb.png $RPM_BUILD_ROOT/usr/share/icons/Adwaita/22x22/devices/generic-usb.png
+mkdir -p $RPM_BUILD_ROOT/usr/share/applications
+cp qubes-update-gui.desktop $RPM_BUILD_ROOT/usr/share/applications/
 
 %post
 touch --no-create %{_datadir}/icons/Adwaita &>/dev/null || :
@@ -108,6 +111,8 @@ gtk-update-icon-cache %{_datadir}/icons/Adwaita &>/dev/null || :
 %{python3_sitelib}/qui/decorators.py
 %{python3_sitelib}/qui/domains_table.py
 %{python3_sitelib}/qui/clipboard.py
+%{python3_sitelib}/qui/updater.py
+%{python3_sitelib}/qui/updater.glade
 
 %dir %{python3_sitelib}/qui/tray/
 %dir %{python3_sitelib}/qui/tray/__pycache__
@@ -116,13 +121,18 @@ gtk-update-icon-cache %{_datadir}/icons/Adwaita &>/dev/null || :
 %{python3_sitelib}/qui/tray/domains.py
 %{python3_sitelib}/qui/tray/devices.py
 %{python3_sitelib}/qui/tray/disk_space.py
+%{python3_sitelib}/qui/tray/updates.py
 
 %{_bindir}/qui-ls
 %{_bindir}/qui-domains
 %{_bindir}/qui-devices
 %{_bindir}/qui-disk-space
+%{_bindir}/qui-updates
+%{_bindir}/qubes-update-gui
 /etc/xdg/autostart/qui-domains.desktop
 /etc/xdg/autostart/qui-devices.desktop
 /etc/xdg/autostart/qui-clipboard.desktop
 /etc/xdg/autostart/qui-disk-space.desktop
+/etc/xdg/autostart/qui-updates.desktop
 /usr/share/icons/Adwaita/22x22/devices/generic-usb.png
+/usr/share/applications/qubes-update-gui.desktop

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,4 @@ setup(name='qui',
               'qubes-update-gui = qui.updater:main'
           ]
       },
-      package_data={'qui': "*.glade"})
+      package_data={'qui': ["updater.glade"]})

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(name='qui',
               'qui-ls = qui.domains_table:main',
               'qui-domains = qui.tray.domains:main',
               'qui-devices = qui.tray.devices:main',
-              'qui-disk-space = qui.tray.disk_space:main'
+              'qui-disk-space = qui.tray.disk_space:main',
+              'qui-updates = qui.tray.updates:main',
+              'qubes-update-gui = qui.updater:main'
           ]
-      })
+      },
+      package_data={'qui': "*.glade"})


### PR DESCRIPTION
A widget that displays an icon and notification
when there are VM updates available and a tool to perform
updates in a pleasant, GUI way without clicking several times
on each VM.
Future improvements need would be displaying some information about which VMs need restarting after the update.

fixes QubesOS/qubes-issues#4400
references QubesOS/qubes-issues#3716
fixes QubesOS/qubes-issues#2718