### PR TITLE
Fixed error on rare cases of DispVM crashing on boot

### DIFF
--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -302,7 +302,7 @@ class DomainTray(Gtk.Application):
         self.register()  # register Gtk Application
 
     def register_events(self):
-        self.dispatcher.add_handler('domain-pre-start', self.add_domain_item)
+        self.dispatcher.add_handler('domain-pre-start', self.update_domain_item)
         self.dispatcher.add_handler('domain-start', self.update_domain_item)
         self.dispatcher.add_handler('domain-start-failed',
                                     self.remove_domain_item)


### PR DESCRIPTION
There's no need to treat domain-pre-start event differently, as
the update_domain_item function already adds the domain if needed.

Fixes https://github.com/QubesOS/qubes-issues/issues/4618