### PR TITLE
Implement widget restarting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
-# How to run:
+# Widgets
 
-- Execute`qui-domains` in a shell.
+Available widgets are:
+- `qui-domains` - Domains Widget, manages running qubes
+- `qui-devices` - Devices Widget, manages attachment/detachment for devices
+- `qui-disk-space` - Disk Space Widget, warns about low disk space
+- `qui-updates` - Updater Widger, notifies about available updates
+
+## How to run
+
+The widgets should be always available in the widget area of the desktop manager.
+They are run (and restarted on crash) by systemd services:
+- qubes-widget@qui-domains
+- qubes-widget@qui-devices
+- qubes-widget@qui-disk-space
+- qubes-widget@qui-updates
+
+In case of problems, you can view system log with `journalctl --user -u qubes-widget@[widget_name]`.

--- a/autostart/qui-devices.desktop
+++ b/autostart/qui-devices.desktop
@@ -2,7 +2,7 @@
 Icon=media-removable
 Name=Devices Tray
 Categories=System;Monitor;
-Exec=python3 -mqui.tray.devices
+Exec=systemctl --user start qubes-widget@qui-devices
 Terminal=false
 Type=Application
 

--- a/autostart/qui-disk-space.desktop
+++ b/autostart/qui-disk-space.desktop
@@ -2,6 +2,6 @@
 Icon=drive-harddisk
 Name=Disk Space Tray
 Categories=System;Monitor;
-Exec=python3 -m qui.tray.disk_space
+Exec=systemctl --user start qubes-widget@qui-disk-space
 Terminal=false
 Type=Application

--- a/autostart/qui-domains.desktop
+++ b/autostart/qui-domains.desktop
@@ -2,6 +2,6 @@
 Icon=qubes
 Name=Domains Tray
 Categories=System;Monitor;
-Exec=python3 -mqui.tray.domains
+Exec=systemctl --user start qubes-widget@qui-domains
 Terminal=false
 Type=Application

--- a/autostart/qui-updates.desktop
+++ b/autostart/qui-updates.desktop
@@ -2,6 +2,6 @@
 Icon=qubes
 Name=Updates Tray
 Categories=System;Monitor;
-Exec=python3 -mqui.tray.updates
+Exec=systemctl --user start qubes-widget@qui-updates
 Terminal=false
 Type=Application

--- a/linux-systemd/qubes-widget@.service
+++ b/linux-systemd/qubes-widget@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ensures Qubes widgets are running and restarting as needed.
+Description=Qubes Widet service
 
 [Service]
 ExecStart=/usr/bin/widget-wrapper %i

--- a/linux-systemd/qubes-widget@.service
+++ b/linux-systemd/qubes-widget@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ensures Qubes widgets are running and restarting as needed.
+
+[Service]
+ExecStart=/usr/bin/widget-wrapper %i
+Restart=on-failure
+RestartSec=1
+StartLimitIntervalSec=5
+StartLimitBurst=3

--- a/qui/widget-wrapper
+++ b/qui/widget-wrapper
@@ -15,11 +15,11 @@ if [[ ${exit_code} -eq 0 ]] ; then
     exit 0
 else
     if xdpyinfo >/dev/null ; then
-    # the xserver is down
+    # it was a genuine crash
         echo "exiting with 1"
         exit ${exit_code}
     else
-        # it was a genuine crash
+        # XServer is down
         echo "exiting with 0"
         exit 0
     fi

--- a/qui/widget-wrapper.sh
+++ b/qui/widget-wrapper.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+
+if [[ $# -lt 1 ]] ; then
+    echo "usage: $0 [program-name]"
+    exit 1
+fi
+
+"$@"
+
+exit_code=$?
+
+if [[ ${exit_code} -eq 0 ]] ; then
+    echo "exiting with 0"
+    exit 0
+else
+    if xdpyinfo >/dev/null ; then
+    # the xserver is down
+        echo "exiting with 1"
+        exit ${exit_code}
+    else
+        # it was a genuine crash
+        echo "exiting with 0"
+        exit 0
+    fi
+fi

--- a/rpm_spec/qubes-desktop-linux-manager.spec
+++ b/rpm_spec/qubes-desktop-linux-manager.spec
@@ -85,7 +85,7 @@ cp icons/22x22/generic-usb.png $RPM_BUILD_ROOT/usr/share/icons/Adwaita/22x22/dev
 mkdir -p $RPM_BUILD_ROOT/usr/share/applications
 cp qubes-update-gui.desktop $RPM_BUILD_ROOT/usr/share/applications/
 mkdir -p $RPM_BUILD_ROOT/usr/lib/qubes/
-cp qui/widget-wrapper.sh $RPM_BUILD_ROOT/usr/bin/widget-wrapper
+cp qui/widget-wrapper $RPM_BUILD_ROOT/usr/bin/widget-wrapper
 mkdir -p $RPM_BUILD_ROOT/lib/systemd/user/
 cp linux-systemd/qubes-widget@.service $RPM_BUILD_ROOT/lib/systemd/user/
 

--- a/rpm_spec/qubes-desktop-linux-manager.spec
+++ b/rpm_spec/qubes-desktop-linux-manager.spec
@@ -84,6 +84,10 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/icons/Adwaita/22x22/devices/
 cp icons/22x22/generic-usb.png $RPM_BUILD_ROOT/usr/share/icons/Adwaita/22x22/devices/generic-usb.png
 mkdir -p $RPM_BUILD_ROOT/usr/share/applications
 cp qubes-update-gui.desktop $RPM_BUILD_ROOT/usr/share/applications/
+mkdir -p $RPM_BUILD_ROOT/usr/lib/qubes/
+cp qui/widget-wrapper.sh $RPM_BUILD_ROOT/usr/bin/widget-wrapper
+mkdir -p $RPM_BUILD_ROOT/lib/systemd/user/
+cp linux-systemd/qubes-widget@.service $RPM_BUILD_ROOT/lib/systemd/user/
 
 %post
 touch --no-create %{_datadir}/icons/Adwaita &>/dev/null || :
@@ -136,3 +140,5 @@ gtk-update-icon-cache %{_datadir}/icons/Adwaita &>/dev/null || :
 /etc/xdg/autostart/qui-updates.desktop
 /usr/share/icons/Adwaita/22x22/devices/generic-usb.png
 /usr/share/applications/qubes-update-gui.desktop
+/usr/bin/widget-wrapper
+/lib/systemd/user/qubes-widget@.service


### PR DESCRIPTION
Widget restarting is provided as a journalctl service (qubes-widget@ template).

fixes QubesOS/qubes-issues#4570
fixes QubesOS/qubes-issues#4397