### PR TITLE
Use update.qubes-vm state for updating, not pkg.upgrade directly

### DIFF
--- a/qui/updater.py
+++ b/qui/updater.py
@@ -186,7 +186,7 @@ class QubesUpdater(Gtk.Application):
                     output = subprocess.check_output(
                         ['sudo', 'qubesctl', '--skip-dom0',
                          '--targets=' + row.vm.name, '--show-output',
-                         'pkg.upgrade', 'refresh=True'],
+                         'state.sls', 'update.qubes-vm'],
                         stderr=subprocess.STDOUT).decode()
 
                 GObject.idle_add(self.append_text_view, output)

--- a/rpm_spec/qubes-desktop-linux-manager.spec
+++ b/rpm_spec/qubes-desktop-linux-manager.spec
@@ -52,6 +52,7 @@ Requires:  libappindicator-gtk3
 Requires:  python3-systemd
 Requires:  gtk3
 Requires:  python3-qubesadmin >= 4.0.16
+Requires:  qubes-mgmt-salt-dom0-update >= 4.0.5
 
 Provides:   qui = %{version}-%{release}
 Obsoletes:  qui < 4.0.0


### PR DESCRIPTION
This allows to apply additional steps before/after actually installing
updates. In this particular case, it's about apt bug (DSA-4371-1), which
could be exploited during normal update.

QubesOS/qubes-issues#4752