### PR TITLE
Better handling of updates available for qui-updates and Qubes Update

### DIFF
--- a/linux-systemd/qubes-widget@.service
+++ b/linux-systemd/qubes-widget@.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Qubes Widet service
+StartLimitIntervalSec=5
 
 [Service]
 ExecStart=/usr/bin/widget-wrapper %i
 Restart=on-failure
 RestartSec=1
-StartLimitIntervalSec=5
 StartLimitBurst=3

--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -95,7 +95,8 @@ class UpdatesTray(Gtk.Application):
     def check_vms_needing_update(self):
         self.vms_needing_update.clear()
         for vm in self.qapp.domains:
-            if vm.features.get('updates-available', False):
+            if vm.features.get('updates-available', False) and \
+                    getattr(vm, 'updateable', False):
                 self.vms_needing_update.add(vm.name)
 
     def connect_events(self):

--- a/qui/updater.glade
+++ b/qui/updater.glade
@@ -80,6 +80,34 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkLabel" id="no_updates_available">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="no_show_all">True</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">No updates have been found.</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="allow_update_unavailable">
+                    <property name="label" translatable="yes">Enable updates for qubes without known available updates</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="name">page_vmlist</property>

--- a/qui/updater.py
+++ b/qui/updater.py
@@ -134,7 +134,8 @@ class QubesUpdater(Gtk.Application):
     def set_update_available(self, _emitter):
         for vm_row in self.vm_list:
             if not vm_row.updates_available:
-                vm_row.set_sensitive(not vm_row.get_sensitive())
+                vm_row.set_sensitive(
+                    self.allow_update_unavailable_check.get_active())
                 if not vm_row.get_sensitive():
                     vm_row.checkbox.set_active(False)
 


### PR DESCRIPTION
Fixed incorrect count of VMs needing an update and added a bunch of QOL
improvements that make it clearer that what checking a VM to be updated
means.
This may be related to a bunch of errors with updates being incorrectly
reported as unavailable.

references QubesOS/qubes-issues#4667
references QubesOS/qubes-issues#4650