### PR TITLE
Add a title to the updater dialog

### DIFF
--- a/qui/updater.glade
+++ b/qui/updater.glade
@@ -6,6 +6,7 @@
     <property name="can_focus">False</property>
     <property name="hexpand">True</property>
     <property name="vexpand">False</property>
+    <property name="title" translatable="yes">Qubes Updater</property>
     <property name="resizable">False</property>
     <child>
       <object class="GtkGrid">
@@ -233,9 +234,6 @@
           <placeholder/>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
At least, I think. I couldn't really test since I don't know how to hook up qubes-builder to point at my fork, and it can't be built standalone (and Glade previews don't actually use this property). But this _seems_ right?