### PR TITLE
Fixed duplicate dom0 in Updater GUI

### DIFF
--- a/qui/updater.py
+++ b/qui/updater.py
@@ -113,7 +113,7 @@ class QubesUpdater(Gtk.Application):
                 self.vm_list.add(VMListBoxRow(vm, state))
 
         for vm in self.qapp.domains:
-            if getattr(vm, 'updateable', False):
+            if getattr(vm, 'updateable', False) and vm.klass != 'AdminVM':
                 state = vm.features.get('updates-available', False)
                 result = result or state
                 self.vm_list.add(VMListBoxRow(vm, state))


### PR DESCRIPTION
Due to fixes in https://github.com/QubesOS/qubes-core-admin/commit/4f71e9775feef68f5ee9ea0fe96be732a7505146  ,
dom0 was appearing twice in Updater GUI list.

fixes QubesOS/qubes-issues#4958