### PR TITLE
Fix clipboard name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ They are run (and restarted on crash) by systemd services:
 - qubes-widget@qui-devices
 - qubes-widget@qui-disk-space
 - qubes-widget@qui-updates
+- qubes-widget@qui-clipboard
 
 In case of problems, you can view system log with `journalctl --user -u qubes-widget@[widget_name]`.

--- a/autostart/qui-clipboard.desktop
+++ b/autostart/qui-clipboard.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Icon=edit-paste
-Name=Domains Tray
+Name=Clipboard Tray
 Categories=System;Monitor;
 Exec=systemctl --user start qubes-widget@qui-clipboard
 Terminal=false


### PR DESCRIPTION
This fixes the name for the clipboard desktop entry. Also adds it to the list in the README.