### PR TITLE
Add dom0

### DIFF
--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -120,7 +120,6 @@ class DomainDecorator(PropertiesDecorator):
                     "\nNetworking: <b>{netvm}</b>" \
                     "\nPrivate storage: <b>{current_storage:.2f}GB/" \
                     "{max_storage:.2f}GB ({perc_storage:.1%})</b>".format(
-                        vmname=self.vm.name,
                         template=self.template_name,
                         netvm=self.netvm_name,
                         current_storage=self.cur_storage,

--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -90,7 +90,7 @@ class DomainDecorator(PropertiesDecorator):
             if self.vm is None:
                 return
 
-            if self.vm.name == 'dom0':
+            if self.vm.klass == 'AdminVM':
                 return
 
             if not self.template_name:

--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -90,6 +90,9 @@ class DomainDecorator(PropertiesDecorator):
             if self.vm is None:
                 return
 
+            if self.vm.name == 'dom0':
+                return
+
             if not self.template_name:
                 self.template_name = getattr(self.vm, 'template', None)
                 self.template_name = "None" if not self.template_name \

--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -90,44 +90,49 @@ class DomainDecorator(PropertiesDecorator):
             if self.vm is None:
                 return
 
+            tooltip = "<b>{vmname}</b>".format(vmname=self.vm.name)
+
             if self.vm.klass == 'AdminVM':
-                return
 
-            if not self.template_name:
-                self.template_name = getattr(self.vm, 'template', None)
-                self.template_name = "None" if not self.template_name \
-                    else str(self.template_name)
+                tooltip += "\nAdministrative domain"
 
-            if not self.netvm_name or netvm_changed:
-                self.netvm_name = getattr(self.vm, 'netvm', None)
-                self.netvm_name = "None" if not self.netvm_name \
-                    else str(self.netvm_name)
+            else:
+                if not self.template_name:
+                    self.template_name = getattr(self.vm, 'template', None)
+                    self.template_name = "None" if not self.template_name \
+                        else str(self.template_name)
 
-            if not self.cur_storage or storage_changed:
-                self.cur_storage = self.vm.get_disk_utilization() / 1024 ** 3
+                if not self.netvm_name or netvm_changed:
+                    self.netvm_name = getattr(self.vm, 'netvm', None)
+                    self.netvm_name = "None" if not self.netvm_name \
+                        else str(self.netvm_name)
 
-            if not self.max_storage or storage_changed:
-                self.max_storage = self.vm.volumes['private'].size / 1024 ** 3
+                if not self.cur_storage or storage_changed:
+                    self.cur_storage = \
+                        self.vm.get_disk_utilization() / 1024 ** 3
 
-            tooltip = \
-                "<b>{vmname}</b>\n" \
-                "Template: <b>{template}</b>\n" \
-                "Networking: <b>{netvm}</b>\n" \
-                "Private storage: <b>{current_storage:.2f}GB/" \
-                "{max_storage:.2f}GB ({perc_storage:.1%})</b>".format(
-                    vmname=self.vm.name,
-                    template=self.template_name,
-                    netvm=self.netvm_name,
-                    current_storage=self.cur_storage,
-                    max_storage=self.max_storage,
-                    perc_storage=self.cur_storage / self.max_storage)
+                if not self.max_storage or storage_changed:
+                    self.max_storage = \
+                        self.vm.volumes['private'].size / 1024 ** 3
 
-            if self.outdated:
-                tooltip += "\n\nRestart qube to " \
-                                  "apply changes in template."
+                tooltip += \
+                    "\nTemplate: <b>{template}</b>" \
+                    "\nNetworking: <b>{netvm}</b>" \
+                    "\nPrivate storage: <b>{current_storage:.2f}GB/" \
+                    "{max_storage:.2f}GB ({perc_storage:.1%})</b>".format(
+                        vmname=self.vm.name,
+                        template=self.template_name,
+                        netvm=self.netvm_name,
+                        current_storage=self.cur_storage,
+                        max_storage=self.max_storage,
+                        perc_storage=self.cur_storage / self.max_storage)
 
-            if self.updates_available:
-                tooltip += "\n\nUpdates available."
+                if self.outdated:
+                    tooltip += "\n\nRestart qube to " \
+                                      "apply changes in template."
+
+                if self.updates_available:
+                    tooltip += "\n\nUpdates available."
 
             self.label.set_tooltip_markup(tooltip)
 

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -382,7 +382,8 @@ class DomainTray(Gtk.Application):
         menu.add(DomainMenuItem(None))
         # sort AdminVM first
         for vm in sorted(self.menu_items,
-                         key=lambda vm: ' ' if vm.klass == 'AdminVM' else vm.name):
+                         key=lambda vm:
+                         ' ' if vm.klass == 'AdminVM' else vm.name):
             self.tray_menu.remove(self.menu_items[vm])
             menu.add(self.menu_items[vm])
             self.menu_items[vm].name.update_tooltip(storage_changed=True)

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -254,6 +254,8 @@ class DomainMenuItem(Gtk.ImageMenuItem):
             self.set_reserve_indicator(True)  # align with submenu triangles
             self.cpu.update_state(header=True)
             self.memory.update_state(header=True)
+        elif self.vm.name == 'dom0':  # no submenu for dom0
+            self.set_reserve_indicator(True)  # align with submenu triangles
         else:
             self.update_state(self.vm.get_power_state())
             self._set_image()
@@ -292,6 +294,11 @@ class DomainMenuItem(Gtk.ImageMenuItem):
         if self.vm is None:
             return
 
+        # dom0 will always be running
+        # dom0 does not have submenu items
+        if self.vm.name == 'dom0':
+            return
+
         if state in ['Running', 'Paused']:
             self.hide_spinner()
         else:
@@ -302,6 +309,7 @@ class DomainMenuItem(Gtk.ImageMenuItem):
                 colormap[state], self.vm.name))
         else:
             self.name.label.set_label(self.vm.name)
+
         self._set_submenu(state)
 
     def update_stats(self, memory_kb, cpu_usage):
@@ -336,6 +344,11 @@ class DomainTray(Gtk.Application):
         self.register_events()
         self.set_application_id(app_name)
         self.register()  # register Gtk Application
+
+        #qapp.log.warning(qapp.domains.keys())
+        # manually insert dom0, since too late for domain-start event
+        self.update_domain_item(qapp.domains['dom0'], '')
+
 
     def register_events(self):
         self.dispatcher.add_handler('domain-pre-start', self.update_domain_item)


### PR DESCRIPTION
This adds dom0 to (the top of) the VM list, making its (large) memory usage and its cpu usage visible.

It has no submenu or tooltip since most of their entries don't apply

dom0 cpu and memory is already tracked along with the other VMs, all this does is display them in the GUI.

On my system, dom0 CPU numbers are consistent with xentop after multiplying by 4 (the number of cores assigned to dom0).