### PR TITLE
Modified 'VM is halting' message to be more true

### DIFF
--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -414,7 +414,8 @@ class DomainTray(Gtk.Application):
         elif event == 'domain-start':
             notification.set_body('Domain {} has started.'.format(vm.name))
         elif event == 'domain-pre-shutdown':
-            notification.set_body('Domain {} is halting.'.format(vm.name))
+            notification.set_body('Domain {} is attempting to shutdown.'.format(
+                vm.name))
         elif event == 'domain-shutdown':
             notification.set_body('Domain {} has halted.'.format(vm.name))
         else:


### PR DESCRIPTION
The VM is not halting, it's attempting to halt,
so now the popup will be "VM attempting to shutdown"

fixes QubesOS/qubes-issues#5237