### PR TITLE
Updated deprecated menu display methods

### DIFF
--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -240,7 +240,7 @@ def device_hbox(device) -> Gtk.Box:
                                device.description)
     if device.attachments:
         name_label.set_markup('<b>{} ({})</b>'.format(
-            name, ", ".join([vm for vm in device.attachments])))
+            name, ", ".join(list(device.attachments))))
     else:
         name_label.set_text(name)
     name_label.set_max_width_chars(64)

--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -305,7 +305,7 @@ class DevicesTray(Gtk.Application):
             if device.backend_domain == name:
                 device.vm_icon = vm.label.icon
 
-    def show_menu(self, _, event):
+    def show_menu(self, _, _event):
         tray_menu = Gtk.Menu()
 
         # create menu items
@@ -326,12 +326,7 @@ class DevicesTray(Gtk.Application):
             tray_menu.add(item)
 
         tray_menu.show_all()
-        tray_menu.popup(None,  # parent_menu_shell
-                        None,  # parent_menu_item
-                        None,  # func
-                        None,  # data
-                        event.button,  # button
-                        Gtk.get_current_event_time())  # activate_time
+        tray_menu.popup_at_pointer(None)  # use current event
 
     def emit_notification(self, title, message, priority, error=False):
         notification = Gio.Notification.new(title)

--- a/qui/tray/disk_space.py
+++ b/qui/tray/disk_space.py
@@ -131,7 +131,7 @@ class DiskSpace(Gtk.Application):
 
         return True  # needed for Gtk to correctly loop the function
 
-    def make_menu(self, _, event):
+    def make_menu(self, _, _event):
         pool_data = PoolUsageData()
 
         menu = Gtk.Menu()
@@ -162,12 +162,7 @@ class DiskSpace(Gtk.Application):
         menu.set_reserve_toggle_size(False)
 
         menu.show_all()
-        menu.popup(None,  # parent_menu_shell
-                   None,  # parent_menu_item
-                   None,  # func
-                   None,  # data
-                   event.button,  # button
-                   Gtk.get_current_event_time())  # activate_time
+        menu.popup_at_pointer(None)  # use current event
 
     @staticmethod
     def make_top_box(pool_data):

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -470,13 +470,8 @@ class DomainTray(Gtk.Application):
 
         self.stats_dispatcher.add_handler('vm-stats', self.update_stats)
 
-    def show_menu(self, _, event):
-        self.tray_menu.popup(None,  # parent_menu_shell
-                             None,  # parent_menu_item
-                             None,  # func
-                             None,  # data
-                             event.button,  # button
-                             Gtk.get_current_event_time())  # activate_time
+    def show_menu(self, _, _event):
+        self.tray_menu.popup_at_pointer(None)  # None means current event
 
     def emit_notification(self, vm, event, **kwargs):
         notification = Gio.Notification.new("Qube Status: {}". format(vm.name))

--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -77,17 +77,12 @@ class UpdatesTray(Gtk.Application):
 
         self.tray_menu.show_all()
 
-    def show_menu(self, _, event):
+    def show_menu(self, _, _event):
         self.tray_menu = Gtk.Menu()
 
         self.setup_menu()
 
-        self.tray_menu.popup(None,  # parent_menu_shell
-                             None,  # parent_menu_item
-                             None,  # func
-                             None,  # data
-                             event.button,  # button
-                             Gtk.get_current_event_time())  # activate_time
+        self.tray_menu.popup_at_pointer(None)  # use current event
 
     @staticmethod
     def launch_updater(*_args, **_kwargs):


### PR DESCRIPTION
We were using Gtk.Menu.popup, which is deprecated and possibly
thus has some bugs. Updated to popup_at_pointer.

fixes QubesOS/qubes-issues#2970