### PR TITLE
Added handling for domain-shutdown-failed event

### DIFF
--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -28,9 +28,9 @@ STATE_DICTIONARY = {
     'domain-paused': 'Paused',
     'domain-unpaused': 'Running',
     'domain-shutdown': 'Halted',
-    'domain-pre-shutdown': 'Transient'
+    'domain-pre-shutdown': 'Transient',
+    'domain-shutdown-failed': 'Running'
 }
-
 
 class IconCache:
     def __init__(self):
@@ -444,6 +444,8 @@ class DomainTray(Gtk.Application):
         self.dispatcher.add_handler('domain-shutdown', self.update_domain_item)
         self.dispatcher.add_handler('domain-pre-shutdown',
                                     self.update_domain_item)
+        self.dispatcher.add_handler('domain-shutdown-failed',
+                                    self.update_domain_item)
 
         self.dispatcher.add_handler('domain-add', self.add_domain_item)
         self.dispatcher.add_handler('domain-delete', self.remove_domain_item)
@@ -455,6 +457,8 @@ class DomainTray(Gtk.Application):
         self.dispatcher.add_handler('domain-pre-shutdown',
                                     self.emit_notification)
         self.dispatcher.add_handler('domain-shutdown', self.emit_notification)
+        self.dispatcher.add_handler('domain-shutdown-failed',
+                                    self.emit_notification)
 
         self.dispatcher.add_handler('domain-start', self.check_pause_notify)
         self.dispatcher.add_handler('domain-paused', self.check_pause_notify)
@@ -497,6 +501,12 @@ class DomainTray(Gtk.Application):
                 vm.name))
         elif event == 'domain-shutdown':
             notification.set_body('Domain {} has halted.'.format(vm.name))
+        elif event == 'domain-shutdown-failed':
+            notification.set_body('Domain {} has failed to shutdown: {}'.format(
+                vm.name, kwargs['reason']))
+            notification.set_priority(Gio.NotificationPriority.HIGH)
+            notification.set_icon(
+                Gio.ThemedIcon.new('dialog-warning'))
         else:
             return
         self.send_notification(None, notification)
@@ -694,6 +704,8 @@ class DomainTray(Gtk.Application):
                                        self.update_domain_item)
         self.dispatcher.remove_handler('domain-pre-shutdown',
                                        self.update_domain_item)
+        self.dispatcher.remove_handler('domain-shutdown-failed',
+                                       self.update_domain_item)
 
         self.dispatcher.remove_handler('domain-add', self.add_domain_item)
         self.dispatcher.remove_handler('domain-delete', self.remove_domain_item)
@@ -706,6 +718,8 @@ class DomainTray(Gtk.Application):
         self.dispatcher.remove_handler('domain-pre-shutdown',
                                        self.emit_notification)
         self.dispatcher.remove_handler('domain-shutdown',
+                                       self.emit_notification)
+        self.dispatcher.remove_handler('domain-shutdown-failed',
                                        self.emit_notification)
 
         self.dispatcher.remove_handler('domain-start', self.check_pause_notify)


### PR DESCRIPTION
Correct handling: notification and changing state.
Requires appropriate changes in QubesAPI to actually do something, but does not cause any problems without it. 
fixes QubesOS/qubes-issues#5380