### PR TITLE
qui-devices improvements

### DIFF
--- a/qui/decorators.py
+++ b/qui/decorators.py
@@ -8,6 +8,7 @@ import gi  # isort:skip
 gi.require_version('Gtk', '3.0')  # isort:skip
 from gi.repository import Gtk, Pango  # isort:skip
 from qubesadmin import exc
+from qubesadmin.utils import size_to_human
 
 import gettext
 t = gettext.translation("desktop-linux-manager", localedir="/usr/locales",
@@ -251,8 +252,13 @@ def device_hbox(device) -> Gtk.Box:
     name_label.set_max_width_chars(64)
     name_label.set_ellipsize(Pango.EllipsizeMode.END)
 
+    size_label = Gtk.Label(xalign=1)
+    if device.devclass == 'block' and 'size' in device.data:
+        size_label.set_text(size_to_human(int(device.data['size'])))
+
     hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
     hbox.pack_start(name_label, True, True, 0)
+    hbox.pack_start(size_label, False, True, 5)
     hbox.pack_start(dev_icon, False, True, 0)
     return hbox
 

--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -163,6 +163,7 @@ class Device:
         self.ident = dev.ident
         self.description = dev.description
         self.devclass = dev.devclass
+        self.data = dev.data
         self.attachments = set()
         self.backend_domain = dev.backend_domain.name
         self.vm_icon = dev.backend_domain.label.icon

--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -18,12 +18,18 @@ import qui.decorators
 import gbulb
 gbulb.install()
 
+
 import gettext
 t = gettext.translation("desktop-linux-manager", localedir="/usr/locales",
                         fallback=True)
 _ = t.gettext
 
 DEV_TYPES = ['block', 'usb', 'mic']
+DEV_TYPE_NAMES = {
+    'block': 'Data (Block) Devices',
+    'usb': 'USB Devices',
+    'mic': 'Audio Input'
+}
 
 
 class DomainMenuItem(Gtk.ImageMenuItem):
@@ -138,6 +144,18 @@ class DeviceItem(Gtk.ImageMenuItem):
 
         self.add(self.hbox)
 
+
+class DevclassHeaderMenuItem(Gtk.MenuItem):
+    """ MenuItem with a header, non-interactive """
+
+    def __init__(self, devclass, *args, **kwargs):
+        super(DevclassHeaderMenuItem, self).__init__(*args, **kwargs)
+
+        label = Gtk.Label(xalign=0)
+        label.set_markup("<b>{}</b>".format(
+            DEV_TYPE_NAMES.get(devclass, "Other Devices")))
+
+        self.add(label)
 
 class Device:
     def __init__(self, dev):
@@ -333,10 +351,14 @@ class DevicesTray(Gtk.Application):
 
         menu_items.sort(key=(lambda x: x.device.devclass + str(x.device)))
 
+        if menu_items:
+            tray_menu.add(DevclassHeaderMenuItem(menu_items[0].device.devclass))
+
         for i, item in enumerate(menu_items):
             if i > 0 and item.device.devclass != \
                     menu_items[i-1].device.devclass:
-                tray_menu.add(Gtk.SeparatorMenuItem())
+                tray_menu.add(
+                    DevclassHeaderMenuItem(menu_items[i].device.devclass))
             tray_menu.add(item)
 
         tray_menu.show_all()


### PR DESCRIPTION
Added device group headers (Audio Input, Data (Block) Devices etc). and block device sizes to qui-devices widget.

Demo image (the PR has Audio Input, the image is from previous version, but it is the only change between it and the final version):
![image](https://user-images.githubusercontent.com/7242298/72386290-6cfa1a80-3721-11ea-8fab-4935e3297215.png)

fixes QubesOS/qubes-issues#5541