### PR TITLE
qui-domains: Do not erroneously report VMs as outdated

### DIFF
--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -649,12 +649,18 @@ class DomainTray(Gtk.Application):
         if event == 'domain-shutdown':
             if getattr(vm, 'klass', None) == 'TemplateVM':
                 for menu_item in self.menu_items.values():
+                    if not menu_item.vm.is_running():
+                        # A VM based on this template can only be
+                        # outdated if the VM is currently running.
+                        continue
                     if getattr(menu_item.vm, 'template', None) == vm:
                         menu_item.name.update_outdated(True)
             # if the VM was shut down, it is no longer outdated
             item.name.update_outdated(False)
 
         if event in ('domain-start', 'domain-pre-start'):
+            # A newly started VM should not be outdated.
+            item.name.update_outdated(False)
             item.show_all()
         if event == 'domain-shutdown':
             item.hide()


### PR DESCRIPTION
Hello @marmarek and @marmarta,

This pull request resolves a minor bug in qui-domains involving needlessly showing VMs as outdated after a template VM is started and shut down. (Please see the commit message for the precise scenario.)

I have tested this commit with Qubes 4.0 only, but it applies cleanly to the `master` branch. I would appreciate it if it could eventually be cherry-picked to the `release4.0` branch, if it is found acceptable for `master`.

Thanks!