### PR TITLE
Error messages from device widget will not be overwritted with normal

### DIFF
--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -372,6 +372,8 @@ class DevicesTray(Gtk.Application):
         notification.set_priority(priority)
         if error:
             notification.set_icon(Gio.ThemedIcon.new('dialog-error'))
+            if notification_id:
+                notification_id += 'ERROR'
         self.send_notification(notification_id, notification)
 
 


### PR DESCRIPTION
Error messages will have now their own message id, so that a device will not hide its error
message with normal messages like 'detached'.
Also fixes a rare fun bug where if there was a normal message after an error, the message
would have had the 'error' icon.