### PR TITLE
Added safeguards for inaccessible vm icon

### DIFF
--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -44,6 +44,7 @@ class DomainMenuItem(Gtk.ImageMenuItem):
         self.device = device
 
         icon = self.vm.icon
+
         self.set_image(qui.decorators.create_icon(icon))
         self._hbox = qui.decorators.device_domain_hbox(self.vm, self.attached)
         self.add(self._hbox)
@@ -166,7 +167,12 @@ class Device:
         self.data = dev.data
         self.attachments = set()
         self.backend_domain = dev.backend_domain.name
-        self.vm_icon = dev.backend_domain.label.icon
+
+        try:
+            self.vm_icon = getattr(dev.backend_domain, 'icon',
+                                   dev.backend_domain.label.icon)
+        except qubesadmin.exc.QubesException:
+            self.vm_icon = 'appvm-black'
 
     def __str__(self):
         return self.dev_name
@@ -179,7 +185,11 @@ class VM:
     def __init__(self, vm):
         self.__hash = hash(vm)
         self.vm_name = vm.name
-        self.icon = vm.label.icon
+
+        try:
+            self.icon = getattr(vm, 'icon', vm.label.icon)
+        except qubesadmin.exc.QubesException:
+            self.icon = 'appvm-black'
 
     def __str__(self):
         return self.vm_name

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -37,6 +37,7 @@ STATE_DICTIONARY = {
     'domain-shutdown-failed': 'Running'
 }
 
+
 class IconCache:
     def __init__(self):
         self.icon_files = {
@@ -535,7 +536,11 @@ class DomainTray(Gtk.Application):
 
     def do_unpause_all(self, _vm, *_args, **_kwargs):
         for vm_name in self.menu_items:
-            self.qapp.domains[vm_name].unpause()
+            try:
+                self.qapp.domains[vm_name].unpause()
+            except exc.QubesException:
+                # we may not have permission to do that
+                pass
 
     def check_pause_notify(self, _vm, _event, **_kwargs):
         if self.have_running_and_all_are_paused():
@@ -562,13 +567,25 @@ class DomainTray(Gtk.Application):
          are created in alphabetical order. Otherwise, this method will
          attempt to sort menu items correctly."""
         # check if it already exists
-        vm = self.qapp.domains[str(vm)]
+        try:
+            vm = self.qapp.domains[str(vm)]
+        except KeyError:
+            # the VM was not created successfully or was deleted before the
+            # event was fully handled
+            return
         if vm in self.menu_items:
             return
 
         state = STATE_DICTIONARY.get(event)
         if not state:
-            state = vm.get_power_state()
+            try:
+                state = vm.get_power_state()
+            except exc.QubesException:
+                # VM might have been already destroyed
+                if vm not in self.qapp.domains:
+                    return
+                # or we might not have permission to access its power state
+                state = 'Halted'
 
         domain_item = DomainMenuItem(vm, self, self.icon_cache, state=state)
         if not event:  # menu item creation at widget start; we can assume


### PR DESCRIPTION
If it is impossible to access VM icon, devices and domains widgets will just show
a black appvm icon.

fixes QubesOS/qubes-issues#5854