### PR TITLE
Make qui-device headers non-clickable

### DIFF
--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -168,6 +168,8 @@ class DevclassHeaderMenuItem(Gtk.MenuItem):
             DEV_TYPE_NAMES.get(devclass, "Other Devices")))
 
         self.add(label)
+        self.set_sensitive(False)
+
 
 class Device:
     def __init__(self, dev):


### PR DESCRIPTION
Changed for ease of testing.