### PR TITLE
Add missing dependency of the clipboard widget

### DIFF
--- a/linux-systemd/qubes-widget@.service
+++ b/linux-systemd/qubes-widget@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Qubes Widet service
+Description=Qubes Widget service
 StartLimitIntervalSec=5
 
 [Service]

--- a/rpm_spec/qubes-desktop-linux-manager.spec.in
+++ b/rpm_spec/qubes-desktop-linux-manager.spec.in
@@ -49,6 +49,7 @@ BuildRequires:  gettext
 
 Requires:  python%{python3_pkgversion}-setuptools
 Requires:  python%{python3_pkgversion}-gbulb
+Requires:  python%{python3_pkgversion}-inotify
 Requires:  libappindicator-gtk3
 Requires:  python%{python3_pkgversion}-systemd
 Requires:  gtk3


### PR DESCRIPTION
Otherwise it crashes on startup with an ModuleNotFoundError.

