### PR TITLE
Dont error on os.makedirs if the directory already exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class InstallWithLocale(setuptools.command.install.install):
                    for l in next(os.walk(localedir))[1]]
         for d in po_dirs:
             mo_dir = os.path.join(self.root, 'usr/share', d)
-            os.makedirs(mo_dir)
+            os.makedirs(mo_dir,exist_ok=True)
             mo_files = []
             po_files = [f
                         for f in next(os.walk(d))[2]


### PR DESCRIPTION
As Title
Closes QubesOs/qubes-issues#7383
