### PR TITLE
Ignore pylint's consider-using-with

### DIFF
--- a/qui/tray/disk_space.py
+++ b/qui/tray/disk_space.py
@@ -101,6 +101,7 @@ class SettingsItem(Gtk.MenuItem):
 
 def launch_preferences_dialog(_, vm):
     vm = str(vm).strip('\'')
+    # pylint: disable=consider-using-with
     subprocess.Popen(['qubes-vm-settings', vm])
 
 

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -219,6 +219,7 @@ class PreferencesItem(Gtk.ImageMenuItem):
         self.connect('activate', self.launch_preferences_dialog)
 
     def launch_preferences_dialog(self, _item):
+        # pylint: disable=consider-using-with
         subprocess.Popen(['qubes-vm-settings', self.vm.name])
 
 
@@ -236,6 +237,7 @@ class LogItem(Gtk.ImageMenuItem):
         self.connect('activate', self.launch_log_viewer)
 
     def launch_log_viewer(self, *_args, **_kwargs):
+        # pylint: disable=consider-using-with
         subprocess.Popen(['qubes-log-viewer', self.path])
 
 
@@ -346,6 +348,7 @@ class DebugMenu(Gtk.Menu):
 
 
 def run_manager(_item):
+    # pylint: disable=consider-using-with
     subprocess.Popen(['qubes-qube-manager'])
 
 

--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -90,6 +90,7 @@ class UpdatesTray(Gtk.Application):
 
     @staticmethod
     def launch_updater(*_args, **_kwargs):
+        # pylint: disable=consider-using-with
         subprocess.Popen(['qubes-update-gui'])
 
     def check_vms_needing_update(self):


### PR DESCRIPTION
Launching a process and not waiting for it is intentional in all those
places. Disable the warning, but only in those places - let it keep warn
about open() and other cases.