### PR TITLE
Qubes Update tool v4.0 - Support controlling the "Details" pane using the keyboard - details_label checkbox

### DIFF
--- a/qui/updater.glade
+++ b/qui/updater.glade
@@ -171,11 +171,12 @@
                     </child>
                     <child>
                       <object class="GtkCheckButton" id="details_label">
-                        <property name="label" translatable="yes">Details</property>
+                        <property name="label" translatable="yes">_Details</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="draw_indicator">True</property>
+                        <property name="use_underline">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/qui/updater.glade
+++ b/qui/updater.glade
@@ -170,16 +170,12 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEventBox" id="details_label_events">
+                      <object class="GtkCheckButton" id="details_label">
+                        <property name="label" translatable="yes">Details</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkLabel" id="details_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Details</property>
-                          </object>
-                        </child>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/qui/updater.py
+++ b/qui/updater.py
@@ -68,8 +68,8 @@ class QubesUpdater(Gtk.Application):
         self.details_icon = self.builder.get_object("details_icon")
         self.builder.get_object("details_icon_events").connect(
             "button-press-event", self.toggle_details)
-        self.builder.get_object("details_label_events").connect(
-            "button-press-event", self.toggle_details)
+        self.builder.get_object("details_label").connect(
+            "clicked", self.toggle_details)
 
         self.load_css()
 


### PR DESCRIPTION
See issue https://github.com/QubesOS/qubes-issues/issues/7635 for details

One possible solution can be conversion window element "Details" from text label to checkbox
