### PR TITLE
Fix policies for Input Devices

### DIFF
--- a/qubes_config/global_config.glade
+++ b/qubes_config/global_config.glade
@@ -867,8 +867,9 @@ Documentation will open in a disposable qube.</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkLabel" id="usb_input_problem_warn_label">
+                                <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Unexpected contents of policy file found.</property>
+                                <property name="label" translatable="yes">Unexpected policy file contents:</property>
                                 <property name="wrap">True</property>
                               </object>
                               <packing>

--- a/qubes_config/global_config/policy_rules.py
+++ b/qubes_config/global_config/policy_rules.py
@@ -232,6 +232,10 @@ class RuleTargetedAdminVM(AbstractRuleWrapper):
             if rule.action.default_target != '@adminvm':
                 raise ValueError(_('If action is ask, '
                                    'default_target must be @adminvm'))
+        if isinstance(rule.action, Allow):
+            if rule.action.target:
+                raise ValueError(_('If action is allow, no '
+                                   'parameters are allowed'))
 
     @property
     def target(self):

--- a/qubes_config/global_config/policy_rules.py
+++ b/qubes_config/global_config/policy_rules.py
@@ -205,6 +205,67 @@ class RuleSimpleNoAllow(RuleSimple):
             return _('Unrecognized action: ') + action
         return None
 
+
+class RuleTargetedAdminVM(AbstractRuleWrapper):
+    """
+    Rule wrapper for rules with the following rules:
+    - source is source
+    - action is main action (e.g. 'allow target=vm' is allow
+    - wrapped rule must have target=@adminvm
+    - if action is ask, wrapped rule must have default_target=@adminvm
+    Returns strings as target/source/action. Target is not settable.
+    """
+    ACTION_CHOICES = {
+        "ask": _("enable"),
+        "allow": _("allow"),
+        "deny": _("disable")
+    }
+
+    def __init__(self, rule: Rule):
+        """
+        :param rule: Rule object
+        """
+        super().__init__(rule)
+        if rule.target != '@adminvm':
+            raise ValueError(_('Target must be @adminvm'))
+        if isinstance(rule.action, Ask):
+            if rule.action.default_target != '@adminvm':
+                raise ValueError(_('If action is ask, '
+                                   'default_target must be @adminvm'))
+
+    @property
+    def target(self):
+        return '@adminvm'
+
+    @target.setter
+    def target(self, new_value):
+        raise ValueError(_('Cannot set target on this type of rule.'))
+
+    @property
+    def source(self):
+        return str(self._rule.source)
+
+    @source.setter
+    def source(self, new_value):
+        new_source = Source(new_value)
+        self._rule.source = new_source
+
+    @property
+    def action(self):
+        return type(self._rule.action).__name__.lower()
+
+    @action.setter
+    def action(self, new_value):
+        new_action = Action[new_value].value(self._rule)
+        self._rule.action = new_action
+        if new_value == 'ask':
+            self._rule.action.default_target = '@adminvm'
+
+    @property
+    def raw_rule(self):
+        return self._rule
+
+
 class RuleTargeted(AbstractRuleWrapper):
     """
     Rule wrapper for rules with the following rules:

--- a/qubes_config/global_config/updates_handler.py
+++ b/qubes_config/global_config/updates_handler.py
@@ -106,6 +106,7 @@ class RepoHandler:
             self.template_community_testing.set_sensitive(True)
 
     def _load_data(self):
+        # pylint: disable=superfluous-parens
         try:
             for row in self._run_qrexec_repo('qubes.repos.List').split('\n'):
                 lst = row.split('\0')
@@ -268,7 +269,7 @@ class UpdateCheckerHandler:
         self.flowbox_handler = VMFlowboxHandler(
             gtk_builder, qapp, "updates_exception",
             initial_vms=self.initial_exceptions,
-            filter_function=(lambda vm: vm.klass != 'AdminVM'))
+            filter_function=lambda vm: vm.klass != 'AdminVM')
 
         self._set_label()
         self.enable_radio.connect('toggled', self._enable_disable_toggled)

--- a/qubes_config/global_config/usb_devices.py
+++ b/qubes_config/global_config/usb_devices.py
@@ -239,7 +239,7 @@ qubes.InputTablet * {self.sys_usb} @adminvm deny
                              width=1, height=1)
 
         # if there are any missing rules, fill them with default
-        for policy_service in self.policy_order.keys():
+        for policy_service in self.policy_order:
             if policy_service in self.action_widgets:
                 continue
             default_rule = [

--- a/qubes_config/tests/test_policy_rules.py
+++ b/qubes_config/tests/test_policy_rules.py
@@ -131,6 +131,15 @@ def test_targeted_rule_weird_cases():
     assert str(wrapped_rule.raw_rule) == \
            str(make_rule('vm1', '@default', 'ask default_target=vm3'))
 
+    wrong_rule = make_rule('vm1', '@adminvm', 'ask default_target=sys-usb')
+    with pytest.raises(ValueError):
+        RuleTargetedAdminVM(wrong_rule)
+
+    wrong_rule_2 = make_rule('vm1', 'sys-usb', 'ask default_target=@adminvm')
+    with pytest.raises(ValueError):
+        RuleTargetedAdminVM(wrong_rule_2)
+
+
 def test_targeted_tokens():
     # can't make a rule with @anyvm target here
     allow_rule = make_rule('vm1', '@anyvm', 'allow')
@@ -200,6 +209,34 @@ def test_targeted_adminvm_change_action():
 
     wrapped_ask.action = 'allow'
     assert str(wrapped_allow.raw_rule) == str(wrapped_ask.raw_rule)
+
+
+def test_targeted_adminvm_change_tokens():
+    allow_rule = make_rule('vm1', '@adminvm', 'allow')
+    ask_rule = make_rule('vm1', '@adminvm', 'ask default_target=@adminvm')
+    deny_rule = make_rule('vm1', '@adminvm', 'deny')
+
+    wrapped_allow = RuleTargetedAdminVM(allow_rule)
+    wrapped_ask = RuleTargetedAdminVM(ask_rule)
+    wrapped_deny = RuleTargetedAdminVM(deny_rule)
+
+    with pytest.raises(ValueError):
+        wrapped_allow.target = 'vm2'
+    with pytest.raises(ValueError):
+        wrapped_ask.target = 'vm2'
+    with pytest.raises(ValueError):
+        wrapped_deny.target = 'vm2'
+
+    wrapped_allow.source = 'vm2'
+    wrapped_ask.source = 'vm2'
+    wrapped_deny.source = 'vm2'
+
+    assert str(wrapped_allow.raw_rule) == \
+           str(make_rule('vm2', '@adminvm', 'allow'))
+    assert str(wrapped_ask.raw_rule) == \
+           str(make_rule('vm2', '@adminvm', 'ask default_target=@adminvm'))
+    assert str(wrapped_deny.raw_rule) == \
+           str(make_rule('vm2', '@adminvm', 'deny'))
 
 
 def test_targeted_fundamental():

--- a/qubes_config/tests/test_policy_rules.py
+++ b/qubes_config/tests/test_policy_rules.py
@@ -23,7 +23,8 @@
 import pytest
 
 from qrexec.policy.parser import Rule
-from ..global_config.policy_rules import RuleSimple, RuleTargeted, RuleDispVM
+from ..global_config.policy_rules import RuleSimple, RuleTargeted,\
+    RuleDispVM, RuleTargetedAdminVM
 
 def make_rule(source, target, action):
     return Rule.from_line(
@@ -78,6 +79,29 @@ def test_targeted_rule():
     assert wrapped_rule.raw_rule == ask_rule
     assert wrapped_rule.source == 'vm1'
     assert wrapped_rule.target == 'vm2'
+    assert wrapped_rule.action == 'ask'
+
+
+def test_targeted_adminvm_rule():
+    deny_rule = make_rule('vm1', '@adminvm', 'deny')
+    wrapped_rule = RuleTargetedAdminVM(deny_rule)
+    assert wrapped_rule.raw_rule == deny_rule
+    assert wrapped_rule.source == 'vm1'
+    assert wrapped_rule.target == '@adminvm'
+    assert wrapped_rule.action == 'deny'
+
+    allow_rule = make_rule('vm1', '@adminvm', 'allow')
+    wrapped_rule = RuleTargetedAdminVM(allow_rule)
+    assert wrapped_rule.raw_rule == allow_rule
+    assert wrapped_rule.source == 'vm1'
+    assert wrapped_rule.target == '@adminvm'
+    assert wrapped_rule.action == 'allow'
+
+    ask_rule = make_rule('vm1', '@adminvm', 'ask default_target=@adminvm')
+    wrapped_rule = RuleTargetedAdminVM(ask_rule)
+    assert wrapped_rule.raw_rule == ask_rule
+    assert wrapped_rule.source == 'vm1'
+    assert wrapped_rule.target == '@adminvm'
     assert wrapped_rule.action == 'ask'
 
 
@@ -153,6 +177,26 @@ def test_targeted_change_action():
 
     wrapped_allow = RuleTargeted(allow_rule)
     wrapped_ask = RuleTargeted(ask_rule)
+
+    wrapped_ask.action = 'allow'
+    assert str(wrapped_allow.raw_rule) == str(wrapped_ask.raw_rule)
+
+
+def test_targeted_adminvm_change_action():
+    allow_rule = make_rule('vm1', '@adminvm', 'allow')
+    ask_rule = make_rule('vm1', '@adminvm', 'ask default_target=@adminvm')
+
+    wrapped_allow = RuleTargetedAdminVM(allow_rule)
+    wrapped_ask = RuleTargetedAdminVM(ask_rule)
+
+    wrapped_allow.action = 'ask'
+    assert str(wrapped_allow.raw_rule) == str(wrapped_ask.raw_rule)
+
+    allow_rule = make_rule('vm1', '@adminvm', 'allow')
+    ask_rule = make_rule('vm1', '@adminvm', 'ask default_target=@adminvm')
+
+    wrapped_allow = RuleTargetedAdminVM(allow_rule)
+    wrapped_ask = RuleTargetedAdminVM(ask_rule)
 
     wrapped_ask.action = 'allow'
     assert str(wrapped_allow.raw_rule) == str(wrapped_ask.raw_rule)

--- a/qubes_config/tests/test_usb_devices.py
+++ b/qubes_config/tests/test_usb_devices.py
@@ -165,7 +165,7 @@ def test_input_devices_no_policy(test_qapp, test_policy_manager, real_builder):
         handler.save()
 
         expected_rules = handler.policy_manager.text_to_rules(
-"""qubes.InputMouse * sys-usb @adminvm ask
+"""qubes.InputMouse * sys-usb @adminvm ask default_target=@adminvm
 qubes.InputKeyboard * sys-usb @adminvm deny
 qubes.InputTablet * sys-usb @adminvm deny
 """)

--- a/qui/clipboard.py
+++ b/qui/clipboard.py
@@ -131,22 +131,21 @@ def clipboard_formatted_size() -> str:
         file_size = os.path.getsize(DATA)
     except OSError:
         return _('? bytes')
+    if file_size == 1:
+        formatted_bytes = _('1 byte')
     else:
-        if file_size == 1:
-            formatted_bytes = _('1 byte')
-        else:
-            formatted_bytes = str(file_size) + _(' bytes')
+        formatted_bytes = str(file_size) + _(' bytes')
 
-        if file_size > 0:
-            magnitude = min(
-                int(math.log(file_size) / math.log(2) * 0.1), len(units) - 1)
-            if magnitude > 0:
-                # pylint: disable=consider-using-f-string
-                return '%s (%.1f %s)' % (formatted_bytes,
-                                         file_size / (2.0**(10 * magnitude)),
-                                         units[magnitude])
-        # pylint: disable=consider-using-f-string
-        return '%s' % (formatted_bytes)
+    if file_size > 0:
+        magnitude = min(
+            int(math.log(file_size) / math.log(2) * 0.1), len(units) - 1)
+        if magnitude > 0:
+            # pylint: disable=consider-using-f-string
+            return '%s (%.1f %s)' % (formatted_bytes,
+                                     file_size / (2.0**(10 * magnitude)),
+                                     units[magnitude])
+    # pylint: disable=consider-using-f-string
+    return '%s' % (formatted_bytes)
 
 
 class NotificationApp(Gtk.Application):

--- a/qui/tray/devices.py
+++ b/qui/tray/devices.py
@@ -407,7 +407,7 @@ class DevicesTray(Gtk.Application):
             device_menu.set_submenu(domain_menu)
             menu_items.append(device_menu)
 
-        menu_items.sort(key=(lambda x: x.device.devclass + str(x.device)))
+        menu_items.sort(key=lambda x: x.device.devclass + str(x.device))
 
         if menu_items:
             tray_menu.add(DevclassHeaderMenuItem(menu_items[0].device.devclass))


### PR DESCRIPTION
Improve error handling (to not crash on unexcepted data and show an error message).
Improve logic: use rules of the form of:
```
sys-usb @adminvm deny
sys-usb @adminvm allow
sys-usb @adminvm ask default_target=@adminvm
```

fixes QubesOS/qubes-issues#8011
fixes QubesOS/qubes-issues#8013