### PR TITLE
Modify submenu for internal qubes in qui-domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ install-icons:
 	cp icons/scalable/check_yes.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/check_yes.svg
 	cp icons/scalable/check_maybe.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/check_maybe.svg
 	cp icons/scalable/qubes_policy_editor.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/qubes-policy-editor.svg
+	cp icons/scalable/qui-domains-scalable.svg $(DESTDIR)/usr/share/icons/hicolor/scalable/apps/qui-domains-scalable.svg
 
 install-autostart:
 	mkdir -p $(DESTDIR)/etc/xdg/autostart

--- a/icons/scalable/qui-domains-scalable.svg
+++ b/icons/scalable/qui-domains-scalable.svg
@@ -1,0 +1,16 @@
+<svg width="23" height="24" viewBox="-2 -2 23 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_0_1012)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.9612 4.26302L9.94139 0.272424C9.64112 0.105153 9.30027 0.00957032 8.95131 0.00160505C8.56177 -0.0143255 8.18846 0.0892229 7.85573 0.272424L0.835888 4.26302C0.430117 4.48605 0.178539 4.85245 0 5.25868L6.44364 8.91473C7.62038 9.58382 8.34265 10.8025 8.34265 12.1327V19.8988C8.87015 20.0502 9.43823 20.0502 9.94139 19.7714L16.9612 15.7808C17.6023 15.4144 18 14.7373 18 14.0205V6.03131C18 5.2985 17.6023 4.62942 16.9612 4.26302Z" fill="#85BCF6"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 13.9771C0 14.7198 0.418803 15.4135 1.09402 15.7889L8.48718 19.8776C8.64957 19.9592 8.82051 19.9592 9 20V12.0511C9 10.6882 8.23932 9.43145 7 8.74592L0.213675 5C0.111111 5.26115 0 5.51415 0 5.79162V13.9771Z" fill="#376594"/>
+<defs>
+<filter id="filter0_d_0_1012" x="0" y="0" width="19" height="20" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.219608 0 0 0 0 0.454902 0 0 0 0 0.847059 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_0_1012"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_0_1012" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/rpm_spec/qubes-desktop-linux-manager.spec.in
+++ b/rpm_spec/qubes-desktop-linux-manager.spec.in
@@ -244,6 +244,7 @@ gtk-update-icon-cache %{_datadir}/icons/Adwaita &>/dev/null || :
 /usr/share/icons/hicolor/scalable/apps/check_maybe.svg
 /usr/share/icons/hicolor/scalable/apps/check_yes.svg
 /usr/share/icons/hicolor/scalable/apps/qubes-policy-editor.svg
+/usr/share/icons/hicolor/scalable/apps/qui-domains-scalable.svg
 
 /usr/share/gtksourceview-4/language-specs/qubes-rpc.lang
 


### PR DESCRIPTION
Now internal qubes get a title and a tooltip explanation, plus the menu has only the shutdown and log options.

Plus improved icon for less clipping.

references QubesOS/qubes-issues#8064