### PR TITLE
Restarting dialog

### DIFF
--- a/qubes_config/global_config/global_config.py
+++ b/qubes_config/global_config/global_config.py
@@ -30,7 +30,7 @@ import qubesadmin
 import qubesadmin.events
 import qubesadmin.exc
 import qubesadmin.vm
-from ..widgets.gtk_utils import show_error, show_dialog, load_theme
+from ..widgets.gtk_utils import show_error, show_dialog_with_icon, load_theme
 from ..widgets.gtk_widgets import ProgressBarDialog, ViewportHandler
 from ..widgets.utils import open_url_in_disposable
 from .page_handler import PageHandler
@@ -366,7 +366,7 @@ class GlobalConfig(Gtk.Application):
 
 
     def _usbvm_changed(self, *_args):
-        response = show_dialog(
+        response = show_dialog_with_icon(
             parent=self.main_window, title=_("USB qube change"),
             text=_("Changing USB qube requires restarting Global Settings to"
                    "correctly initialize all defaults. "
@@ -458,7 +458,7 @@ class GlobalConfig(Gtk.Application):
         box.pack_start(label_2, False, False, 10)
         box.pack_start(label_3, False, False, 10)
 
-        response = show_dialog(
+        response = show_dialog_with_icon(
             parent=self.main_window, title=_("Unsaved changes"), text=box,
             buttons={
                 _("_Save changes"): Gtk.ResponseType.YES,

--- a/qubes_config/global_config/policy_handler.py
+++ b/qubes_config/global_config/policy_handler.py
@@ -28,7 +28,7 @@ from qrexec.policy.parser import Rule
 from qrexec.exc import PolicySyntaxError
 
 from ..widgets.gtk_widgets import VMListModeler, ExpanderHandler
-from ..widgets.gtk_utils import show_error, ask_question, show_dialog
+from ..widgets.gtk_utils import show_error, ask_question, show_dialog_with_icon
 from .page_handler import PageHandler
 from .policy_rules import AbstractRuleWrapper, AbstractVerbDescription
 from .policy_manager import PolicyManager
@@ -328,7 +328,7 @@ class PolicyHandler(PageHandler):
                 if not row.is_changed():
                     row.set_edit_mode(False)
                     continue
-                response = show_dialog(
+                response = show_dialog_with_icon(
                     parent=row.get_toplevel(), title=_("Unsaved changes"),
                     text=_("A rule is currently being edited. \n"
                          "Do you want to save changes to the following"

--- a/qubes_config/tests/test_global_config.py
+++ b/qubes_config/tests/test_global_config.py
@@ -39,6 +39,11 @@ from gi.repository import Gtk
 # a test_builder fixture is requested because it will try to register
 # signals in "test" mode
 
+
+show_dialog_with_icon_path = \
+    'qubes_config.global_config.global_config.show_dialog_with_icon'
+
+
 @patch('subprocess.check_output')
 @patch('qubes_config.global_config.global_config.show_error')
 def test_global_config_init(mock_error, mock_subprocess,
@@ -70,8 +75,7 @@ def test_global_config_init(mock_error, mock_subprocess,
     handler.copy_combo.set_active_id('Ctrl+Win+C')
 
     # try to move away from page, we should get a warning
-    with patch('qubes_config.global_config.global_config.show_dialog') \
-            as mock_ask:
+    with patch(show_dialog_with_icon_path) as mock_ask:
         mock_ask.return_value = Gtk.ResponseType.NO
         app.main_notebook.set_current_page(clipboard_page_num + 1)
 
@@ -82,8 +86,8 @@ def test_global_config_init(mock_error, mock_subprocess,
     handler.copy_combo.set_active_id('Ctrl+Win+C')
 
     # try to move away from page, we should get a warning
-    with patch('qubes_config.global_config.global_config.show_dialog') \
-            as mock_ask, patch('qubes_config.global_config.basics_handler.'
+    with patch(show_dialog_with_icon_path) as mock_ask, \
+            patch('qubes_config.global_config.basics_handler.'
                'apply_feature_change') as mock_apply:
         mock_ask.return_value = Gtk.ResponseType.YES
         app.main_notebook.set_current_page(clipboard_page_num + 1)
@@ -214,8 +218,7 @@ def test_global_config_page_change(mock_error, mock_subprocess,
         assert False  # didn't find the change
 
     # try to switch pages but refuse to save changes
-    with patch('qubes_config.global_config.global_config.show_dialog') \
-        as mock_ask:
+    with patch(show_dialog_with_icon_path) as mock_ask:
         mock_ask.return_value = Gtk.ResponseType.NO
         app.main_notebook.next_page()
         mock_ask.assert_called()
@@ -241,8 +244,7 @@ def test_global_config_page_change(mock_error, mock_subprocess,
         handler.filecopy_handler.policy_file_name]
 
     # save changes
-    with patch('qubes_config.global_config.global_config.show_dialog') \
-        as mock_ask:
+    with patch(show_dialog_with_icon_path) as mock_ask:
         mock_ask.return_value = Gtk.ResponseType.YES
         app.main_notebook.next_page()
         mock_ask.assert_called()
@@ -275,10 +277,9 @@ def test_global_config_failure(mock_error, mock_subprocess,
     handler.fullscreen_combo.set_active_id('disallow')
 
     # try to switch pages, error will occur on saving
-    with patch('qubes_config.global_config.global_config.show_dialog') \
-        as mock_ask, \
-            patch('qubes_config.global_config.global_config.'
-                  'GLib.timeout_add') as mock_timeout:
+    with patch(show_dialog_with_icon_path) as mock_ask, \
+            patch('qubes_config.global_config.global_config.GLib.timeout_add') \
+                    as mock_timeout:
         mock_ask.return_value = Gtk.ResponseType.YES
         app.main_notebook.next_page()
         mock_ask.assert_called()

--- a/qubes_config/tests/test_policy_exceptions_handler.py
+++ b/qubes_config/tests/test_policy_exceptions_handler.py
@@ -32,6 +32,11 @@ from gi.repository import Gtk
 # policyexctest  -> missing tests!
 # dispvmexctest
 
+
+show_dialog_with_icon_path = \
+    'qubes_config.global_config.policy_handler.show_dialog_with_icon'
+
+
 def test_policy_exc_handler_empty(test_builder, test_qapp, test_policy_manager):
     handler = DispvmExceptionHandler(
         qapp=test_qapp,
@@ -272,8 +277,7 @@ TestService * test-red @dispvm ask default_target=@dispvm:default-dvm"""
             assert row.target_widget.combobox.get_visible()
             row.target_widget.model.select_value('@dispvm')
             # second activation cannot cause the changes to be discarded
-            with patch('qubes_config.global_config.policy_handler.'
-                       'show_dialog') as mock_ask:
+            with patch(show_dialog_with_icon_path) as mock_ask:
                 row.activate()
                 row.activate()
                 assert not mock_ask.mock_calls
@@ -324,8 +328,7 @@ TestService * test-red @dispvm ask default_target=@dispvm:default-dvm"""
                               current_policy_rules)
 
     # click another row, dismiss message
-    with patch('qubes_config.global_config.policy_handler.show_dialog') as \
-            mock_ask:
+    with patch(show_dialog_with_icon_path) as mock_ask:
         mock_ask.return_value = Gtk.ResponseType.NO
         for row in handler.list_handler.current_rows:
             if row != found_row:
@@ -350,8 +353,7 @@ TestService * test-red @dispvm ask default_target=@dispvm:default-dvm"""
     else:
         assert False # expected rule to edit not found!
 
-    with patch('qubes_config.global_config.policy_handler.show_dialog') as \
-            mock_ask:
+    with patch(show_dialog_with_icon_path) as mock_ask:
         mock_ask.return_value = Gtk.ResponseType.YES
         for row in handler.list_handler.current_rows:
             if row != found_row:
@@ -398,9 +400,9 @@ TestService * test-red @dispvm ask default_target=@dispvm:default-dvm"""
         assert False # expected rule to edit not found!
 
     # click another row, but, say you want to save changes, fail
-    with patch('qubes_config.global_config.policy_handler.show_dialog') as \
-            mock_ask, patch('qubes_config.global_config.rule_list_widgets'
-                            '.show_error') as mock_error:
+    with patch(show_dialog_with_icon_path) as mock_ask, \
+            patch('qubes_config.global_config.rule_list_widgets.show_error') \
+                    as mock_error:
         mock_ask.return_value = Gtk.ResponseType.YES
         for row in handler.list_handler.current_rows:
             if row != found_row:

--- a/qubes_config/tests/test_policy_handler.py
+++ b/qubes_config/tests/test_policy_handler.py
@@ -32,6 +32,10 @@ gi.require_version('GdkPixbuf', '2.0')
 from gi.repository import Gtk
 
 
+show_dialog_with_icon_path = \
+    'qubes_config.global_config.policy_handler.show_dialog_with_icon'
+
+
 def add_rule(handler, source = None, target = None,
              action = None, expect_error: bool = False):
     # attempt to add a new rule
@@ -371,8 +375,7 @@ TestService * @anyvm @anyvm deny"""
             assert row.target_widget.combobox.get_visible()
             row.target_widget.model.select_value('test-red')
             # second activation cannot cause the changes to be discarded
-            with patch('qubes_config.global_config.policy_handler.'
-                       'show_dialog') as mock_ask:
+            with patch(show_dialog_with_icon_path) as mock_ask:
                 row.activate()
                 row.activate()
                 assert not mock_ask.mock_calls
@@ -420,8 +423,7 @@ TestService * @anyvm @anyvm deny"""
     assert compare_rule_lists(handler.current_rules, default_policy_rules)
 
     # click another row, dismiss message
-    with patch('qubes_config.global_config.policy_handler.show_dialog') as \
-            mock_ask:
+    with patch(show_dialog_with_icon_path) as mock_ask:
         mock_ask.return_value = Gtk.ResponseType.NO
         for row in handler.current_rows:
             if row != found_row:
@@ -445,8 +447,7 @@ TestService * @anyvm @anyvm deny"""
     else:
         assert False # expected rule to edit not found!
 
-    with patch('qubes_config.global_config.policy_handler.show_dialog') as \
-            mock_ask:
+    with patch(show_dialog_with_icon_path) as mock_ask:
         mock_ask.return_value = Gtk.ResponseType.YES
         for row in handler.current_rows:
             if row != found_row:
@@ -494,9 +495,9 @@ TestService * @anyvm @anyvm deny"""
         assert False # expected rule to edit not found!
 
     # click another row, but, say you want to save changes, fail
-    with patch('qubes_config.global_config.policy_handler.show_dialog') as \
-            mock_ask, patch('qubes_config.global_config.rule_list_widgets'
-                            '.show_error') as mock_error:
+    with patch(show_dialog_with_icon_path) as mock_ask, \
+            patch('qubes_config.global_config.rule_list_widgets.show_error') \
+                    as mock_error:
         mock_ask.return_value = Gtk.ResponseType.YES
         for row in handler.current_rows:
             if row != found_row:

--- a/qubes_config/widgets/gtk_utils.py
+++ b/qubes_config/widgets/gtk_utils.py
@@ -113,15 +113,7 @@ def show_dialog_with_icon(
         icon_name: str
 ) -> Gtk.ResponseType:
     """
-    Show a dialog.
-    :param parent: parent widget, preferably the top level window
-    :param title: title of the prompt
-    :param text: prompt text (can use pango markup)
-    :param
-    :param buttons: dict of button-text: response type to use
-    :param icon_name: name of the icon to be show on the right side of
-    the question
-    :return: which button was pressed
+    Helper function to show a dialog with icon given by name.
     """
     icon = Gtk.Image.new_from_pixbuf(load_icon(icon_name, 48, 48))
     dialog = show_dialog(parent, title, text, buttons, icon)
@@ -145,7 +137,15 @@ def show_dialog(
         widget: Gtk.Widget
 ) -> Gtk.ResponseType:
     """
-    TODO
+    Show a dialog.
+    :param parent: parent widget, preferably the top level window
+    :param title: title of the prompt
+    :param text: prompt text (can use pango markup)
+    :param
+    :param buttons: dict of button-text: response type to use
+    :param widget: widget to be show on the right side of
+    the question
+    :return: which button was pressed
     """
     dialog: Gtk.Dialog = Gtk.Dialog.new()
     dialog.set_modal(True)

--- a/qubes_config/widgets/gtk_utils.py
+++ b/qubes_config/widgets/gtk_utils.py
@@ -23,7 +23,7 @@ import os
 
 import fcntl
 
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -88,20 +88,30 @@ def show_error(parent, title, text):
     """
     Helper function to display error messages.
     """
-    return show_dialog(parent=parent, title=title, text=text,
-                       buttons=RESPONSES_OK, icon_name="qubes-info")
+    return show_dialog_with_icon(parent=parent, title=title, text=text,
+                                 buttons=RESPONSES_OK, icon_name="qubes-info")
 
 
 def ask_question(parent, title: str, text: str):
     """
     Helper function to show question dialogs.
     """
-    return show_dialog(parent=parent, title=title, text=text,
-                       buttons=RESPONSES_YES_NO_CANCEL, icon_name="qubes-ask")
+    return show_dialog_with_icon(
+        parent=parent,
+        title=title,
+        text=text,
+        buttons=RESPONSES_YES_NO_CANCEL,
+        icon_name="qubes-ask"
+    )
 
-def show_dialog(parent: Gtk.Widget, title: str, text: Union[str, Gtk.Widget],
-                buttons: Dict[str, Gtk.ResponseType],
-                icon_name: str) -> Gtk.ResponseType:
+
+def show_dialog_with_icon(
+        parent: Optional[Gtk.Widget],
+        title: str,
+        text: Union[str, Gtk.Widget],
+        buttons: Dict[str, Gtk.ResponseType],
+        icon_name: str
+) -> Gtk.ResponseType:
     """
     Show a dialog.
     :param parent: parent widget, preferably the top level window
@@ -112,6 +122,30 @@ def show_dialog(parent: Gtk.Widget, title: str, text: Union[str, Gtk.Widget],
     :param icon_name: name of the icon to be show on the right side of
     the question
     :return: which button was pressed
+    """
+    icon = Gtk.Image.new_from_pixbuf(load_icon(icon_name, 48, 48))
+    dialog = show_dialog(parent, title, text, buttons, icon)
+    response = dialog.run()
+    dialog.destroy()
+    if response == Gtk.ResponseType.DELETE_EVENT:
+        if Gtk.ResponseType.CANCEL in buttons.values():
+        # treat exiting from the window as cancel if it's one of the
+        # available responses, then no if it's one of the available responses
+            return Gtk.ResponseType.CANCEL
+        if Gtk.ResponseType.NO in buttons.values():
+            return Gtk.ResponseType.NO
+    return response
+
+
+def show_dialog(
+        parent: Gtk.Widget,
+        title: str,
+        text: Union[str, Gtk.Widget],
+        buttons: Dict[str, Gtk.ResponseType],
+        widget: Gtk.Widget
+) -> Gtk.ResponseType:
+    """
+    TODO
     """
     dialog: Gtk.Dialog = Gtk.Dialog.new()
     dialog.set_modal(True)
@@ -136,8 +170,7 @@ def show_dialog(parent: Gtk.Widget, title: str, text: Union[str, Gtk.Widget],
     box.get_style_context().add_class('modal_contents')
     content_area.pack_start(box, False, False, 0)
 
-    icon = Gtk.Image.new_from_pixbuf(load_icon(icon_name, 48, 48))
-    box.pack_start(icon, False, False, 0)
+    box.pack_start(widget, False, False, 0)
 
     if isinstance(text, str):
         label: Gtk.Label = Gtk.Label()
@@ -151,18 +184,7 @@ def show_dialog(parent: Gtk.Widget, title: str, text: Union[str, Gtk.Widget],
         box.pack_start(text, False, False, 40)
 
     dialog.show_all()
-
-    response = dialog.run()
-    dialog.destroy()
-
-    if response == Gtk.ResponseType.DELETE_EVENT:
-        if Gtk.ResponseType.CANCEL in buttons.values():
-        # treat exiting from the window as cancel if it's one of the
-        # available responses, then no if it's one of the available responses
-            return Gtk.ResponseType.CANCEL
-        if Gtk.ResponseType.NO in buttons.values():
-            return Gtk.ResponseType.NO
-    return response
+    return dialog
 
 
 def load_theme(widget: Gtk.Widget, light_theme_path: str, dark_theme_path: str):

--- a/qui/updater/tests/conftest.py
+++ b/qui/updater/tests/conftest.py
@@ -271,3 +271,23 @@ def appvms_list(test_qapp, mock_list_store):
         if vm.klass == "AppVM":
             result.append_vm(vm)
     return result
+
+
+@pytest.fixture
+def mock_thread():
+    class MockThread:
+        def __init__(self):
+            self.started = False
+            self.alive_requests_max: int = 3
+            self.alive_request = 0
+
+        def start(self):
+            self.started = True
+
+        def is_alive(self):
+            self.alive_request += 1
+            if self.alive_request > self.alive_requests_max:
+                return False
+            return True
+
+    return MockThread()

--- a/qui/updater/tests/test_progress_page.py
+++ b/qui/updater/tests/test_progress_page.py
@@ -35,17 +35,9 @@ from qui.updater.utils import ListWrapper, UpdateStatus
 
 @patch('threading.Thread')
 def test_init_update(
-        mock_threading, real_builder, test_qapp,
+        mock_threading, mock_thread, real_builder, test_qapp,
         mock_next_button, mock_cancel_button, mock_label, mock_tree_view,
         all_vms_list):
-    class MockThread:
-        def __init__(self):
-            self.started = False
-
-        def start(self):
-            self.started = True
-
-    mock_thread = MockThread()
 
     mock_threading.return_value = mock_thread
 

--- a/qui/updater/tests/test_summary_page.py
+++ b/qui/updater/tests/test_summary_page.py
@@ -22,12 +22,11 @@ import pytest
 from unittest.mock import patch, call
 
 import gi
+gi.require_version('Gtk', '3.0')  # isort:skip
+from gi.repository import Gtk  # isort:skip
 
 from qubes_config.widgets.gtk_utils import RESPONSES_OK
 from qui.updater.intro_page import UpdateRowWrapper
-
-gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import Gtk  # isort:skip
 
 from qui.updater.summary_page import SummaryPage, AppVMType, RestartStatus, \
     RestartRowWrapper

--- a/qui/updater/tests/test_updater_settings.py
+++ b/qui/updater/tests/test_updater_settings.py
@@ -1,0 +1,264 @@
+# coding=utf-8
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2023  Piotr Bartman <prbartman@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+import gi
+import pytest
+
+gi.require_version('Gtk', '3.0')  # isort:skip
+from gi.repository import Gtk
+
+from qui.updater.updater_settings import Settings
+
+
+def init_features(test_qapp):
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+    ] = b"0\x00" + str(1).encode()
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-other', None)
+    ] = b"0\x00" + str(1).encode()
+    test_qapp.expected_calls[
+        (
+        'dom0', 'admin.vm.feature.Get', 'qubes-vm-update-max-concurrency', None)
+    ] = b"0\x00" + str(1).encode()
+
+
+def test_show_and_hide(test_qapp):
+    init_features(test_qapp)
+    sut = Settings(Gtk.Window(), test_qapp, lambda *args: None)
+    sut.show()
+    sut.close_without_saving(None, None)
+
+
+def test_update_if_stale(test_qapp):
+    sut = Settings(Gtk.Window(), test_qapp, lambda *args: None)
+    assert sut.update_if_stale == 7
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-update-if-stale', None)
+    ] = b"0\x00" + str(32).encode()
+    assert sut.update_if_stale == 32
+    test_qapp.expected_calls[
+        (
+        'dom0', 'admin.vm.feature.Get', 'qubes-vm-update-update-if-stale', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+            + b'qubes-vm-update-update-if-stale' + b'\x00'
+    assert sut.update_if_stale == 7
+
+
+def test_restart_system_vms(test_qapp):
+    sut = Settings(Gtk.Window(), test_qapp, lambda *args: None)
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+        + b'qubes-vm-update-restart-system' + b'\x00'
+    assert sut.restart_system_vms
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+    ] = b"0\x00" + ''.encode()
+    assert not sut.restart_system_vms
+    test_qapp.expected_calls[
+        (
+        'dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+            + b'qubes-vm-update-restart-system' + b'\x00'
+    assert sut.restart_system_vms
+
+
+def test_restart_other_vms(test_qapp):
+    sut = Settings(Gtk.Window(), test_qapp, lambda *args: None)
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-other', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+        + b'qubes-vm-update-restart-other' + b'\x00'
+    assert not sut.restart_other_vms
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-other', None)
+    ] = b"0\x00" + '1'.encode()
+    assert sut.restart_other_vms
+    test_qapp.expected_calls[
+        (
+        'dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-other', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+            + b'qubes-vm-update-restart-other' + b'\x00'
+    assert not sut.restart_other_vms
+
+
+def test_max_concurrency(test_qapp):
+    sut = Settings(Gtk.Window(), test_qapp, lambda *args: None)
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get',
+         'qubes-vm-update-max-concurrency', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+        + b'qubes-vm-update-max-concurrency' + b'\x00'
+    assert sut.max_concurrency is None
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get',
+         'qubes-vm-update-max-concurrency', None)
+    ] = b"0\x00" + '8'.encode()
+    assert sut.max_concurrency == 8
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get',
+         'qubes-vm-update-max-concurrency', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+            + b'qubes-vm-update-max-concurrency' + b'\x00'
+    assert sut.max_concurrency is None
+
+
+class MockCallback:
+    def __init__(self):
+        self.call_num = 0
+        self.value = None
+
+    def __call__(self, value):
+        self.call_num += 1
+        self.value = value
+
+
+@pytest.mark.parametrize(
+    "feature, default_value, new_value, button_name",
+    (
+        pytest.param("update-if-stale", Settings.DEFAULT_UPDATE_IF_STALE, 30,
+                     "days_without_update_button"),
+        pytest.param("restart-system", Settings.DEFAULT_RESTART_SYSTEM_VMS,
+                     False, "restart_system_checkbox"),
+        pytest.param("restart-other", Settings.DEFAULT_RESTART_OTHER_VMS,
+                     True, "restart_other_checkbox"),
+    ),
+)
+def test_save(feature, default_value, new_value, test_qapp, button_name):
+    mock_callback = MockCallback()
+    sut = Settings(Gtk.Window(), test_qapp, mock_callback)
+
+    init_features(test_qapp)
+    sut.show()
+    sut.save_and_close(None)
+
+    assert mock_callback.call_num == 1
+    if feature == "update-if-stale":
+        assert mock_callback.value == default_value
+
+    # set feature
+    sut.show()
+    button = getattr(sut, button_name)
+    if button_name.endswith("checkbox"):
+        button.set_active(new_value)
+        new_value_str = '1' if new_value else ''
+    else:
+        button.set_value(new_value)
+        new_value_str = str(new_value)
+
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Set',
+         f'qubes-vm-update-{feature}', new_value_str.encode())
+    ] = b'0\x00'
+    sut.save_and_close(None)
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get', f'qubes-vm-update-{feature}', None)
+    ] = b"0\x00" + str(new_value).encode()
+
+    assert mock_callback.call_num == 2
+    if feature == "update-if-stale":
+        assert mock_callback.value == default_value
+
+    # set different value for feature
+    sut.show()
+    if button_name.endswith("checkbox"):
+        button.set_active(default_value)
+    else:
+        button.set_value(default_value)
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Set',
+         f'qubes-vm-update-{feature}', None)
+    ] = b'0\x00'
+    sut.save_and_close(None)
+    assert mock_callback.call_num == 3
+    if feature == "update-if-stale":
+        assert mock_callback.value == new_value
+    test_qapp.expected_calls[
+        ('dom0', 'admin.vm.feature.Get',
+         f'qubes-vm-update-{feature}', None)
+    ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
+        + f'qubes-vm-update-{feature}'.encode() + b'\x00'
+
+
+    # do not set adminVM feature if nothing change
+    sut.show()
+    del test_qapp.expected_calls[('dom0', 'admin.vm.feature.Set',
+         f'qubes-vm-update-{feature}', None)]
+    if button_name.endswith("checkbox"):
+        button.set_active(default_value)
+    else:
+        button.set_value(default_value)
+    sut.save_and_close(None)
+    assert mock_callback.call_num == 4
+    if feature == "update-if-stale":
+        assert mock_callback.value == default_value
+
+
+def test_limit_concurrency(test_qapp):
+    dom0_set_max_concurrency = ('dom0', 'admin.vm.feature.Set',
+                                f'qubes-vm-update-max-concurrency',)
+    dom0_get_max_concurrency = ('dom0', 'admin.vm.feature.Get',
+                                f'qubes-vm-update-max-concurrency', None)
+
+    sut = Settings(Gtk.Window(), test_qapp, lambda *args: None)
+
+    #  False
+
+    init_features(test_qapp)
+
+    # Set True
+    sut.show()
+    sut.limit_concurrency_checkbox.set_active(True)
+    test_qapp.expected_calls[
+        (*dom0_set_max_concurrency, sut.DEFAULT_CONCURRENCY)
+    ] = b'0\x00'
+    sut.save_and_close(None)
+    test_qapp.expected_calls[dom0_get_max_concurrency] = \
+        b"0\x00" + str(sut.DEFAULT_CONCURRENCY).encode()
+
+    # Set concurrency to max value
+    sut.show()
+    sut.max_concurrency_button.set_value(Settings.MAX_CONCURRENCY)
+    test_qapp.expected_calls[
+        (*dom0_set_max_concurrency, sut.MAX_CONCURRENCY)
+    ] = b'0\x00'
+    sut.save_and_close(None)
+    test_qapp.expected_calls[dom0_get_max_concurrency] = \
+        b"0\x00" + str(sut.MAX_CONCURRENCY).encode()
+
+    # Set concurrency to max value again
+    sut.show()
+    sut.limit_concurrency_checkbox.set_active(True)
+    del test_qapp.expected_calls[
+        (*dom0_set_max_concurrency, sut.DEFAULT_CONCURRENCY)
+    ]
+    sut.save_and_close(None)
+
+    # Set False
+    sut.show()
+    sut.limit_concurrency_checkbox.set_active(False)
+    test_qapp.expected_calls[
+        (*dom0_set_max_concurrency, None)
+    ] = b'0\x00'
+    sut.save_and_close(None)
+
+
+

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # pylint: disable=wrong-import-position,import-error
-import threading
 import time
 
 import pkg_resources
 import gi  # isort:skip
 
 from qubes_config.widgets.gtk_utils import load_icon_at_gtk_size, load_theme, \
-    show_dialog_with_icon, RESPONSES_OK, show_dialog, show_error
+    show_dialog_with_icon, RESPONSES_OK
 from qui.updater.progress_page import ProgressPage
 from qui.updater.updater_settings import Settings
-from qui.updater.summary_page import SummaryPage, RestartStatus
+from qui.updater.summary_page import SummaryPage
 from qui.updater.intro_page import IntroPage
 
 gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import Gtk, Gdk, GLib, Gio  # isort:skip
+from gi.repository import Gtk, Gdk, Gio  # isort:skip
 from qubesadmin import Qubes
 
 # using locale.gettext is necessary for Gtk.Builder translation support to work

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # pylint: disable=wrong-import-position,import-error
+import threading
 import time
 
 import pkg_resources
 import gi  # isort:skip
 
 from qubes_config.widgets.gtk_utils import load_icon_at_gtk_size, load_theme, \
-    show_dialog, RESPONSES_OK
+    show_dialog_with_icon, RESPONSES_OK, show_dialog, show_error
 from qui.updater.progress_page import ProgressPage
 from qui.updater.updater_settings import Settings
-from qui.updater.summary_page import SummaryPage
+from qui.updater.summary_page import SummaryPage, RestartStatus
 from qui.updater.intro_page import IntroPage
 
 gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import Gtk, Gdk, Gio  # isort:skip
+from gi.repository import Gtk, Gdk, GLib, Gio  # isort:skip
 from qubesadmin import Qubes
 
 # using locale.gettext is necessary for Gtk.Builder translation support to work
@@ -163,10 +164,10 @@ class QubesUpdater(Gtk.Application):
         if self.progress_page.update_thread \
                 and self.progress_page.update_thread.is_alive():
             self.progress_page.exit_triggered = True
-            show_dialog(self.main_window, l("Updating cancelled"), l(
+            show_dialog_with_icon(self.main_window, l("Updating cancelled"), l(
                     "Waiting for current qube to finish updating."
                     " Updates for remaining qubes have been cancelled."),
-                        buttons=RESPONSES_OK, icon_name="qubes-info")
+                                  buttons=RESPONSES_OK, icon_name="qubes-info")
 
             while self.progress_page.update_thread.is_alive():
                 while Gtk.events_pending():

--- a/qui/updater/updater_settings.py
+++ b/qui/updater/updater_settings.py
@@ -79,6 +79,8 @@ class Settings:
 
         self.restart_system_checkbox: Gtk.CheckButton = self.builder.get_object(
             "restart_system")
+        self.restart_system_checkbox.connect(
+            "toggled", self._show_restart_exceptions)
 
         self.restart_other_checkbox: Gtk.CheckButton = self.builder.get_object(
             "restart_other")

--- a/qui/updater/updater_settings.py
+++ b/qui/updater/updater_settings.py
@@ -38,6 +38,13 @@ GObject.signal_new('child-removed',
 
 
 class Settings:
+    DEFAULT_CONCURRENCY = 4
+    MAX_CONCURRENCY = 16
+    DEFAULT_UPDATE_IF_STALE = 7
+    MAX_UPDATE_IF_STALE = 99
+    DEFAULT_RESTART_SYSTEM_VMS = True
+    DEFAULT_RESTART_OTHER_VMS = False
+
     def __init__(self, main_window, qapp, refresh_callback: Callable):
         self.qapp = qapp
         self.refresh_callback = refresh_callback
@@ -64,7 +71,10 @@ class Settings:
 
         self.days_without_update_button: Gtk.SpinButton = \
             self.builder.get_object("days_without_update")
-        adj = Gtk.Adjustment(7, 1, 100, 1, 1, 1)
+        adj = Gtk.Adjustment(
+            Settings.DEFAULT_UPDATE_IF_STALE, 1, Settings.MAX_UPDATE_IF_STALE,
+            1, 1, 1
+        )
         self.days_without_update_button.configure(adj, 1, 0)
 
         self.restart_system_checkbox: Gtk.CheckButton = self.builder.get_object(
@@ -94,7 +104,10 @@ class Settings:
             "toggled", self._limit_concurrency_toggled)
         self.max_concurrency_button: Gtk.SpinButton = \
             self.builder.get_object("max_concurrency")
-        adj = Gtk.Adjustment(4, 1, 17, 1, 1, 1)
+        adj = Gtk.Adjustment(
+            Settings.DEFAULT_CONCURRENCY, 1, Settings.MAX_CONCURRENCY + 1,
+            1, 1, 1
+        )
         self.max_concurrency_button.configure(adj, 1, 0)
 
         self._init_update_if_stale: Optional[int] = None
@@ -106,19 +119,22 @@ class Settings:
     @property
     def update_if_stale(self) -> int:
         """Return the current (set by this window or manually) option value."""
-        return int(get_feature(self.vm, "qubes-vm-update-update-if-stale", 7))
+        return int(get_feature(self.vm, "qubes-vm-update-update-if-stale",
+                               Settings.DEFAULT_UPDATE_IF_STALE))
 
     @property
     def restart_system_vms(self) -> bool:
         """Return the current (set by this window or manually) option value."""
         return get_boolean_feature(
-            self.vm, "qubes-vm-update-restart-system", True)
+            self.vm, "qubes-vm-update-restart-system",
+            Settings.DEFAULT_RESTART_SYSTEM_VMS)
 
     @property
     def restart_other_vms(self) -> bool:
         """Return the current (set by this window or manually) option value."""
         return get_boolean_feature(
-            self.vm, "qubes-vm-update-restart-other", False)
+            self.vm, "qubes-vm-update-restart-other",
+            Settings.DEFAULT_RESTART_OTHER_VMS)
 
     @property
     def max_concurrency(self) -> Optional[int]:
@@ -173,21 +189,21 @@ class Settings:
             name="update-if-stale",
             value=int(self.days_without_update_button.get_value()),
             init=self._init_update_if_stale,
-            default=7
+            default=Settings.DEFAULT_UPDATE_IF_STALE
         )
 
         self._save_option(
             name="restart-system",
             value=self.restart_system_checkbox.get_active(),
             init=self._init_restart_system_vms,
-            default=True
+            default=Settings.DEFAULT_RESTART_SYSTEM_VMS
         )
 
         self._save_option(
             name="restart-other",
             value=self.restart_other_checkbox.get_active(),
             init=self._init_restart_other_vms,
-            default=False
+            default=Settings.DEFAULT_RESTART_OTHER_VMS
         )
 
         limit_concurrency = self.limit_concurrency_checkbox.get_active()


### PR DESCRIPTION
After clicking "Finish and restart N qubes" there is a spinner dialog waiting for all affected VMs to restart/shut-down.

As an additional feature: show exclude VM flowbox if any of the "restart sys-vms/other-vms" options are checked. This is because we can and probably want to exclude some sys-vm from automatic restart.