### PR TITLE
Lazy-load available applications in new qube

### DIFF
--- a/qubes_config/new_qube.glade
+++ b/qubes_config/new_qube.glade
@@ -125,6 +125,14 @@
                             <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="valign">start</property>
+                            <child type="placeholder">
+                              <object class="GtkButton" id="apps_list_load_all">
+                                <property name="label" translatable="yes">Load applications available in other templates</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                              </object>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/qubes_config/new_qube/application_selector.py
+++ b/qubes_config/new_qube/application_selector.py
@@ -221,6 +221,8 @@ class ApplicationBoxHandler:
             gtk_builder.get_object('apps_list_other_templates')
         self.label_other_templates: Gtk.Label = gtk_builder.get_object(
             'label_other_templates')
+        self.load_all_button: Gtk.Button = \
+            gtk_builder.get_object('apps_list_load_all')
 
         self.change_template_msg: Gtk.Dialog = gtk_builder.get_object(
             'msg_change_template')
@@ -253,6 +255,7 @@ class ApplicationBoxHandler:
         self.apps_list.set_sort_func(self._sort_func_app_list)
         self.apps_list_other.set_sort_func(self._sort_func_app_list)
         self.apps_list_other.set_filter_func(self._filter_func_other_list)
+        self.load_all_button.connect('clicked', self._load_all_apps)
 
         self.flowbox.set_sort_func(self._sort_flowbox)
 
@@ -297,6 +300,23 @@ class ApplicationBoxHandler:
                 x.appdata.template):
             return False
         return self._filter_func_app_list(x)
+
+    def _load_all_apps(self, *_args):
+        self.load_all_button.set_label("Loading applications...")
+
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+
+        self.template_selector.load_all_available_apps()
+        self._fill_others_list()
+        self.apps_list_other.invalidate_filter()
+
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+
+        self.apps_list_other.set_visible(True)
+        self.load_all_button.set_label("No matching applications found")
+        self.load_all_button.set_sensitive(False)
 
     @staticmethod
     def _row_activated(listbox: Gtk.ListBox, row: ApplicationRow):

--- a/qubes_config/tests/test_new_qube/test_application_selector.py
+++ b/qubes_config/tests/test_new_qube/test_application_selector.py
@@ -21,7 +21,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
 # pylint: disable=protected-access
-
+import time
 from unittest.mock import patch
 
 from ...new_qube.application_selector import ApplicationBoxHandler, \
@@ -254,6 +254,8 @@ def test_app_handler_do_template(mock_subprocess,
     app_selector.apps_search.set_text('Udon')
 
     assert app_selector.apps_list_placeholder.get_visible()
+    app_selector.load_all_button.clicked()
+    time.sleep(1)
 
     for child in app_selector.apps_list_other.get_children():
         # as we cannot use mapping in tests, let's just check the filter

--- a/qubes_config/tests/test_new_qube/test_new_qube.py
+++ b/qubes_config/tests/test_new_qube/test_new_qube.py
@@ -167,8 +167,8 @@ def test_complex_new_qube(mock_error, mock_subprocess,
                in mock_popen.mock_calls
 
     mock_error.assert_not_called()
-    # no more subprocess calls
-    assert num_setup_calls == len(mock_subprocess.mock_calls)
+    # 2 additional calls were made: to list available apps and default apps
+    assert num_setup_calls + 2 == len(mock_subprocess.mock_calls)
 
 
 @patch('subprocess.check_output', side_effect = mock_output)
@@ -226,8 +226,9 @@ def test_new_template_cloned(mock_error, mock_subprocess,
         assert not mock_popen.mock_calls  # no apps added
 
     mock_error.assert_not_called()
-    # no more subprocess calls
-    assert num_setup_calls == len(mock_subprocess.mock_calls)
+    # 2 additional subprocess calls to get all apps and available apps for
+    # the new template
+    assert num_setup_calls + 2 == len(mock_subprocess.mock_calls)
 
 
 @patch('subprocess.check_output', side_effect = mock_output)
@@ -290,7 +291,7 @@ def test_new_standalone(mock_error, mock_subprocess,
                      '--update', ANY], stdin=-1) not in mock_popen.mock_calls
 
     mock_error.assert_not_called()
-    # no more subprocess calls
+    # no more subprocess calls, no actual new template was selected
     assert num_setup_calls == len(mock_subprocess.mock_calls)
 
 
@@ -352,8 +353,9 @@ def test_new_disposable(mock_error, mock_subprocess,
         assert not mock_popen.mock_calls  # no apps added
 
     mock_error.assert_not_called()
-    # no more subprocess calls
-    assert num_setup_calls == len(mock_subprocess.mock_calls)
+    # 2 additional subprocess calls to get all apps and available apps for
+    # the new template
+    assert num_setup_calls + 2 == len(mock_subprocess.mock_calls)
 
 
 @patch('subprocess.check_output', side_effect = mock_output)


### PR DESCRIPTION
Make the loading less burdensome at start. Load apps on template switch (should be not terribly slow, unless someone has a template with hundreds of apps).