### PR TITLE
Add missing gnome-icon-theme dependency

### DIFF
--- a/rpm_spec/qubes-desktop-linux-manager.spec.in
+++ b/rpm_spec/qubes-desktop-linux-manager.spec.in
@@ -60,6 +60,7 @@ Requires:  qubes-artwork >= 4.1.5
 # for qui/widget-wrapper
 Requires:  xhost
 Requires:  gtksourceview4
+Requires:  gnome-icon-theme
 
 Provides:   qui = %{version}-%{release}
 Obsoletes:  qui < 4.0.0


### PR DESCRIPTION
This is needed for icon loading to work.

Fixes: QubesOS/qubes-issues#8226