### PR TITLE
Global config: if policy files do not exist, do not create them

### DIFF
--- a/qubes_config/global_config/policy_manager.py
+++ b/qubes_config/global_config/policy_manager.py
@@ -74,7 +74,7 @@ class PolicyManager:
     def get_rules_from_filename(self, filename: str, default_policy: str) -> \
             Tuple[List[Rule], Optional[str]]:
         """Get rules contained in a provided file. If the file does not exist,
-        populate it with provided default policy and return the contents.
+        return default policy.
         Return list of Rule objects and str of the PolicyClient's token
         for the file."""
         try:
@@ -82,8 +82,7 @@ class PolicyManager:
         except subprocess.CalledProcessError:
             if not default_policy:
                 return [], None
-            self.policy_client.policy_replace(filename, default_policy)
-            rules_text, token = self.policy_client.policy_get(filename)
+            rules_text, token = default_policy, None
 
         rules = self.text_to_rules(rules_text)
 

--- a/qubes_config/tests/test_global_config.py
+++ b/qubes_config/tests/test_global_config.py
@@ -160,9 +160,13 @@ def test_global_config_page_change(mock_error, mock_subprocess,
             child.activate()
             child.source_widget.model.select_value('sys-net')
             child.validate_and_save()
+            break
+    else:
+        assert False
 
-    old_text = test_policy_manager.policy_client.files[
-        handler.filecopy_handler.policy_file_name]
+    # file should not yet exist
+    assert handler.filecopy_handler.policy_file_name not in \
+           test_policy_manager.policy_client.files
 
     # save changes
     with patch(show_dialog_with_icon_path) as mock_ask:
@@ -175,7 +179,7 @@ def test_global_config_page_change(mock_error, mock_subprocess,
     time.sleep(0.1)
 
     # changes should have been done
-    assert old_text != test_policy_manager.policy_client.files[
+    assert 'sys-net' in test_policy_manager.policy_client.files[
         handler.filecopy_handler.policy_file_name]
 
     mock_error.assert_not_called()

--- a/qubes_config/tests/test_policy_manager.py
+++ b/qubes_config/tests/test_policy_manager.py
@@ -77,10 +77,12 @@ def test_get_policy_from_file_new():
 
     test_default = 'Test\t*\t@anyvm\t@anyvm\tdeny'
 
+    # token should be None (the file is new), but rules should be appropriate
     got_rules, token = manager.get_rules_from_filename('test', test_default)
-    assert token == 'test'
+    assert token is None
     assert len(got_rules) == 1
     assert str(got_rules[0]) == test_default
+    assert 'test' not in manager.policy_client.files
 
 
 def test_get_policy_from_file_existing():


### PR DESCRIPTION
By default, if policy files don't exist, they won't be created.