### PR TITLE
qubes-vm-update: add CLI options

### DIFF
--- a/qubes_config/tests/conftest.py
+++ b/qubes_config/tests/conftest.py
@@ -217,6 +217,10 @@ def add_feature_to_all(qapp, feature_name, enable_vm_names: List[str]):
 
 @pytest.fixture
 def test_qapp():
+    return test_qapp_impl()
+
+
+def test_qapp_impl():
     """Test QubesApp"""
     qapp = QubesTest()
     qapp._local_name = 'dom0'  # pylint: disable=protected-access

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -201,9 +201,10 @@ class IntroPage:
             self.log.debug("Command returns: %s", output.decode())
 
             to_update = {
-                vm_name.strip() for vm_name
-                in output.decode().split("\n", maxsplit=1)[0]
-                .split(":", maxsplit=1)[1].split(",")}
+                vm_name.strip()
+                for line in output.decode().split("\n", maxsplit=1)
+                for vm_name in line.split(":", maxsplit=1)[1].split(",")
+            }
 
         # handle dom0
         if cliargs.dom0 or cliargs.all:

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -175,6 +175,47 @@ class IntroPage:
             row.selected = row.updates_available \
                            in self.head_checkbox.allowed
 
+    def select_rows_ignoring_conditions(self, cliargs):
+        cmd = ['qubes-vm-update', '--dry-run']
+
+        args = [a for a in dir(cliargs) if not a.startswith("_")]
+        for arg in args:
+            if arg in ("dom0", "no-restart", "restart", "max_concurrency",
+                       "log"):
+                continue
+            value = getattr(cliargs, arg)
+            if value:
+                if arg in ("skip", "targets"):
+                    vms = set(value.split(","))
+                    vms_without_dom0 = vms.difference({"dom0"})
+                    if not vms_without_dom0:
+                        continue
+                    value = ",".join(vms_without_dom0)
+                cmd.extend((f"--{arg.replace('_', '-')}", str(value)))
+
+        if not cmd[2:]:
+            to_update = set()
+        else:
+            self.log.debug("Run command %s", " ".join(cmd))
+            output = subprocess.check_output(cmd)
+            self.log.debug("Command returns: %s", output.decode())
+
+            to_update = {
+                vm_name.strip() for vm_name
+                in output.decode().split("\n", maxsplit=1)[0]
+                .split(":", maxsplit=1)[1].split(",")}
+
+        # handle dom0
+        if cliargs.dom0 or cliargs.all:
+            to_update.add("dom0")
+        if cliargs.targets and "dom0" in cliargs.targets.split(","):
+            to_update.add("dom0")
+        if cliargs.skip and "dom0" in cliargs.skip.split(","):
+            to_update = to_update.difference({"dom0"})
+
+        for row in self.list_store:
+            row.selected = row.name in to_update
+
 
 class UpdateRowWrapper(RowWrapper):
     COLUMN_NUM = 9

--- a/qui/updater/tests/test_updater.py
+++ b/qui/updater/tests/test_updater.py
@@ -20,14 +20,14 @@
 # USA.
 from unittest.mock import patch, call
 
-from qui.updater.updater import QubesUpdater
+from qui.updater.updater import QubesUpdater, parse_args
 
 
 @patch('logging.FileHandler')
 @patch('logging.getLogger')
 @patch('qui.updater.intro_page.IntroPage.populate_vm_list')
 def test_setup(populate_vm_list, _mock_logging, __mock_logging, test_qapp):
-    sut = QubesUpdater(test_qapp)
+    sut = QubesUpdater(test_qapp, parse_args(()))
     sut.perform_setup()
     calls = [call(sut.qapp, sut.settings)]
     populate_vm_list.assert_has_calls(calls)


### PR DESCRIPTION
resolves https://github.com/QubesOS/qubes-issues/issues/8355 

Now it is possible to start gui updater with cli options.
If you chose directly which vms should be updated intro_page will be skipped. 
If you run updater with explicitly given option this will override option in settings.

Use `qubes-updater-gui --help` for more info