### PR TITLE
Make sure all qubes are shown in domains widget 

### DIFF
--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -495,6 +495,7 @@ class DomainMenuItem(Gtk.ImageMenuItem):
         if state == 'Halted':
             self.hide()
             return
+        self.show_all()
 
         if state in ['Running', 'Paused']:
             self.hide_spinner()


### PR DESCRIPTION
Make sure that a qube that didn't manage to get its
'domain-started' event (because it happened in the
middle of initialization of the widget) processed
is still shown.

fixes https://github.com/QubesOS/qubes-issues/issues/8373