### PR TITLE
Rename qrexec-policy-editor to qrexec-policy-editor-gui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install-autostart:
 	cp linux-systemd/qubes-widget@.service $(DESTDIR)/lib/systemd/user/
 	cp desktop/qubes-global-config.desktop $(DESTDIR)/usr/share/applications/
 	cp desktop/qubes-new-qube.desktop $(DESTDIR)/usr/share/applications/
-	cp desktop/qubes-policy-editor.desktop $(DESTDIR)/usr/share/applications/
+	cp desktop/qubes-policy-editor-gui.desktop $(DESTDIR)/usr/share/applications/
 
 install-lang:
 	mkdir -p $(DESTDIR)/usr/share/gtksourceview-4/language-specs/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In case of problems, you can view system log with `journalctl --user -u qubes-wi
 
 To run the policy editor, use
 ```commandline
-$ qubes-policy-editor file_name
+$ qubes-policy-editor-gui file_name
 ```
 
 You can use an existing policy file name to edit an existing file (e.g. `90-default`),

--- a/desktop/qubes-policy-editor-gui.desktop
+++ b/desktop/qubes-policy-editor-gui.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=qubes-policy-editor
+Exec=qubes-policy-editor-gui
 Icon=qubes-global-config
 Terminal=false
 Name=Qubes Policy Editor

--- a/rpm_spec/qubes-desktop-linux-manager.spec.in
+++ b/rpm_spec/qubes-desktop-linux-manager.spec.in
@@ -206,11 +206,11 @@ gtk-update-icon-cache %{_datadir}/icons/Adwaita &>/dev/null || :
 
 /usr/share/applications/qubes-global-config.desktop
 /usr/share/applications/qubes-new-qube.desktop
-/usr/share/applications/qubes-policy-editor.desktop
+/usr/share/applications/qubes-policy-editor-gui.desktop
 
 %{_bindir}/qubes-new-qube
 %{_bindir}/qubes-global-config
-%{_bindir}/qubes-policy-editor
+%{_bindir}/qubes-policy-editor-gui
 
 /usr/share/icons/hicolor/16x16/apps/qui-domains.png
 /usr/share/icons/hicolor/24x24/apps/qui-domains.png

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
             'qui-clipboard = qui.clipboard:main',
             'qubes-new-qube = qubes_config.new_qube.new_qube_app:main',
             'qubes-global-config = qubes_config.global_config.global_config:main',
-            'qubes-policy-editor = qubes_config.policy_editor.policy_editor:main'
+            'qubes-policy-editor-gui = qubes_config.policy_editor.policy_editor:main'
         ]
     },
     package_data={'qui': ["updater.glade",


### PR DESCRIPTION
This makes space for the non-GUI version.