### PR TITLE
updater: always show main window, even if no updates are available

### DIFF
--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -58,8 +58,6 @@ class QubesUpdater(Gtk.Application):
             self.perform_setup()
             self.primary = True
             self.hold()
-        elif len(self.intro_page.get_vms_to_update()) == 0:
-            self.exit_updater()
         else:
             self.main_window.present()
 


### PR DESCRIPTION
Not showing the window is confusing (user starts the app and nothing
happens). And also not showing it prevents forcing an update.

Fixes QubesOS/qubes-issues#8549