### PR TITLE
update-gui: Remove checkbox for restarting VMs on the main page

### DIFF
--- a/qui/updater.glade
+++ b/qui/updater.glade
@@ -224,6 +224,7 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin-top">20</property>
+                    <property name="margin-bottom">20</property>
                     <property name="label" translatable="yes">Qubes OS checks for updates for running and networked qubes and their templates. Updates may also be available in other qubes, marked as {MAYBE} above.</property>
                     <property name="use-markup">True</property>
                     <property name="wrap">True</property>
@@ -235,37 +236,6 @@
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="restart_button">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="margin-bottom">20</property>
-                    <property name="use-underline">True</property>
-                    <property name="draw-indicator">True</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="valign">start</property>
-                        <property name="margin-top">15</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">_Restart updated qubes after install
-CAUTION: this may cause data loss if you are currently running programs in those qubes</property>
-                        <property name="use-underline">True</property>
-                        <style>
-                          <class name="explanation_text"/>
-                        </style>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -81,9 +81,6 @@ class IntroPage:
                 MAYBE=f'<span foreground="{label_color_theme("orange")}">'
                       '<b>MAYBE</b></span>'))
 
-        self.restart_button: Gtk.CheckButton = self.builder.get_object(
-            "restart_button")
-
     def populate_vm_list(self, qapp, settings):
         """Adds to list any updatable vms with an update info."""
         self.log.debug("Populate update list")

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -188,7 +188,7 @@ class QubesUpdater(Gtk.Application):
         elif self.progress_page.is_visible:
             if not self.summary_page.is_populated:
                 self.summary_page.populate_restart_list(
-                    restart=self.intro_page.restart_button.get_active(),
+                    restart=True,
                     vm_updated=self.progress_page.vms_to_update,
                     settings=self.settings
                 )


### PR DESCRIPTION
User can always deselect qubes on the summary page, so always select
qubes according to the settings, without needing one extra checkbox.

Fixes QubesOS/qubes-issues#8686