### PR TITLE
qubes-update: real-time output

### DIFF
--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -290,6 +290,8 @@ class ProgressPage:
                     curr_name_out = maybe_name[:-suffix]
                 if curr_name_out:
                     rows[curr_name_out].append_text_view(text)
+                if curr_name_out == self.update_details.active_row.name:
+                    self.update_details.update_buffer()
             else:
                 break
         self.update_details.update_buffer()

--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -219,7 +219,7 @@ class ProgressPage:
         Use rpm to return the installed packages and their versions.
         """
 
-        cmd = ["rpm", "-qa", "--queryformat", "%{NAME} %{VERSION}%{RELEASE}\n",]
+        cmd = ["rpm", "-qa", "--queryformat", "%{NAME} %{VERSION}-%{RELEASE}\n",]
         # EXAMPLE OUTPUT:
         # qubes-core-agent 4.1.351.fc34
         package_list = subprocess.check_output(cmd).decode().splitlines()

--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -264,7 +264,7 @@ class ProgressPage:
             for pkg in changes["updated"]:
                 old_ver = str(changes["updated"][pkg]["old"])[2:-2]
                 new_ver = str(changes["updated"][pkg]["new"])[2:-2]
-                result += f'{pkg} {old_ver} -> {new_ver}'
+                result += f'{pkg} {old_ver} -> {new_ver}\n'
         else:
             result += "None\n"
 

--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -156,6 +156,7 @@ class ProgressPage:
 
         try:
             with Ticker(admin):
+                # pylint: disable=consider-using-with
                 proc = subprocess.Popen(
                     ['sudo', 'qubes-dom0-update'],
                     stderr=subprocess.PIPE, stdout=subprocess.PIPE)


### PR DESCRIPTION
Now updater shows what is going on in real-time.

connected to QubesOS/qubes-core-admin-linux#141
closes QubesOS/qubes-issues#8564
Better output reporting, should fixes QubesOS/qubes-issues#8323
Not using salt to update dom0 fixes QubesOS/qubes-issues#8779
