### PR TITLE
Improve "needs updateproxy" logic in global config

### DIFF
--- a/qubes_config/global_config/policy_handler.py
+++ b/qubes_config/global_config/policy_handler.py
@@ -395,8 +395,8 @@ class RawPolicyTextHandler:
     def __init__(self, gtk_builder: Gtk.Builder, prefix: str,
                  policy_manager: PolicyManager,
                  error_handler: 'ErrorHandler',
-                 callback_on_save_raw: Callable[[List[Rule]], None],
-                 callback_on_open_raw: Callable):
+                 callback_on_save_raw: Optional[Callable[[List[Rule]], None]],
+                 callback_on_open_raw: Optional[Callable]):
         """
         :param gtk_builder: Gtk.Builder
         :param prefix: prefix for widgets

--- a/qubes_config/global_config/updates_handler.py
+++ b/qubes_config/global_config/updates_handler.py
@@ -429,7 +429,8 @@ class UpdateProxy:
             return False
         if getattr(vm, 'template', None):
             return False
-        return not vm.is_networked()
+        return bool(vm.features.check_with_template(
+            'service.updates-proxy-setup', vm.klass == 'TemplateVM'))
 
     def load_rules(self):
         """Load rules into widgets."""

--- a/qubes_config/new_qube/template_handler.py
+++ b/qubes_config/new_qube/template_handler.py
@@ -83,6 +83,7 @@ class TemplateSelector(abc.ABC):
         if widget is None or widget.get_active():
             self.main_window.emit('template-changed', self.get_selected_vm())
 
+    @abc.abstractmethod
     def is_vm_available(self, vm: qubesadmin.vm.QubesVM) -> bool:
         """
         Check if the given VM is available in the template list.

--- a/qubes_config/tests/conftest.py
+++ b/qubes_config/tests/conftest.py
@@ -302,6 +302,8 @@ def test_qapp_impl():
 
     add_feature_with_template_to_all(qapp, 'supported-service.qubes-u2f-proxy',
                                      ['test-vm', 'fedora-35', 'sys-usb'])
+    add_feature_with_template_to_all(qapp, 'service.updates-proxy-setup',
+                                     ['fedora-36', 'fedora-35'])
     add_feature_to_all(qapp, 'service.qubes-u2f-proxy',
                                      ['test-vm'])
 
@@ -326,6 +328,9 @@ def test_qapp_whonix(test_qapp):  # pylint: disable=redefined-outer-name
                     {"netvm": ("vm", False, '')},
                     {'service.qubes-update-check': None}, ['whonix-updatevm'])
     test_qapp.domains.clear_cache()
+    add_feature_with_template_to_all(
+        test_qapp, 'service.updates-proxy-setup',
+        ['fedora-36', 'fedora-35', 'whonix-gw-15', 'whonix-gw-14'])
     return test_qapp
 
 @pytest.fixture


### PR DESCRIPTION
Use the updates-proxy-setup feature instead of guessing based on network access.

fixes QubesOS/qubes-issues#8851