### PR TITLE
updater: better restarting logic

### DIFF
--- a/qui/updater/tests/conftest.py
+++ b/qui/updater/tests/conftest.py
@@ -230,6 +230,7 @@ def mock_list_store():
             self.raw_rows.remove(idx)
 
         def set_sort_func(self, _col, _sort_func, _data):
+            """not used in tests"""
             pass
 
     return MockListStore()
@@ -240,7 +241,7 @@ def mock_settings():
     class MockSettings:
         def __init__(self):
             self.update_if_stale = 7
-            self.restart_system_vms = True
+            self.restart_service_vms = True
             self.restart_other_vms = True
             self.max_concurrency = None
 

--- a/qui/updater/tests/test_summary_page.py
+++ b/qui/updater/tests/test_summary_page.py
@@ -78,14 +78,14 @@ def test_on_header_toggled(
 
     sut.list_store = appvms_list
     all_num = len(appvms_list)
-    sut.head_checkbox._allowed[0] = AppVMType.SYS
-    sys_num = 3
-    sut.head_checkbox._allowed[1] = AppVMType.NON_SYS
+    sut.head_checkbox._allowed[0] = AppVMType.SERVICEVM
+    service_num = 3
+    sut.head_checkbox._allowed[1] = AppVMType.NON_SERVICEVM
     non_excluded_num = 6
 
     sut.head_checkbox.state = HeaderCheckbox.NONE
 
-    for expected in (0, sys_num, non_excluded_num, all_num, 0):
+    for expected in (0, service_num, non_excluded_num, all_num, 0):
         selected_num = len([row for row in sut.list_store if row.selected])
         assert selected_num == expected
         assert sut.head_checkbox_button.get_inconsistent() \
@@ -109,8 +109,8 @@ def test_on_checkbox_toggled(
     )
 
     sut.list_store = appvms_list
-    sut.head_checkbox._allowed[0] = AppVMType.SYS
-    sut.head_checkbox._allowed[1] = AppVMType.NON_SYS
+    sut.head_checkbox._allowed[0] = AppVMType.SERVICEVM
+    sut.head_checkbox._allowed[1] = AppVMType.NON_SERVICEVM
 
     sut.head_checkbox.state = HeaderCheckbox.NONE
     sut.head_checkbox.set_buttons()
@@ -153,30 +153,30 @@ def test_on_checkbox_toggled(
 
 # expected data based on test_qapp setup
 UP_VMS = 7
-UP_SYS_VMS = 3
+UP_SERVICE_VMS = 3
 UP_APP_VMS = 4
 
 
 @pytest.mark.parametrize(
-    "restart_system_vms, restart_other_vms, excluded, expected",
+    "restart_service_vms, restart_other_vms, excluded, expected",
     (
         pytest.param(True, True, (), UP_VMS),
-        pytest.param(True, False, (), UP_SYS_VMS),
+        pytest.param(True, False, (), UP_SERVICE_VMS),
         pytest.param(False, False, (), 0),
         pytest.param(False, True, (), UP_APP_VMS),
         pytest.param(True, True, ("test-blue",), UP_VMS - 1),
-        pytest.param(True, False, ("test-blue",), UP_SYS_VMS),
+        pytest.param(True, False, ("test-blue",), UP_SERVICE_VMS),
         pytest.param(False, True, ("sys-usb",), UP_APP_VMS),
-        pytest.param(True, False, ("sys-usb",), UP_SYS_VMS - 1),
+        pytest.param(True, False, ("sys-usb",), UP_SERVICE_VMS - 1),
     ),
 )
 def test_populate_restart_list(
-        restart_system_vms, restart_other_vms, excluded, expected,
+        restart_service_vms, restart_other_vms, excluded, expected,
         real_builder, test_qapp, updatable_vms_list,
         mock_next_button, mock_cancel_button, mock_settings, mock_tree_view
 ):
     mock_settings.restart_other_vms = restart_other_vms
-    mock_settings.restart_system_vms = restart_system_vms
+    mock_settings.restart_service_vms = restart_service_vms
     for exclude in excluded:
         test_qapp.expected_calls[
             (exclude, "admin.vm.feature.Get", 'restart-after-update', None)

--- a/qui/updater/tests/test_updater_settings.py
+++ b/qui/updater/tests/test_updater_settings.py
@@ -31,7 +31,7 @@ from qui.updater.updater_settings import Settings
 
 def init_features(test_qapp):
     test_qapp.expected_calls[
-        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-servicevms', None)
     ] = b"0\x00" + str(1).encode()
     test_qapp.expected_calls[
         ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-other', None)
@@ -66,24 +66,24 @@ def test_update_if_stale(test_qapp):
     assert sut.update_if_stale == 7
 
 
-def test_restart_system_vms(test_qapp):
+def test_restart_service_vms(test_qapp):
     mock_log = Mock()
     sut = Settings(Gtk.Window(), test_qapp, mock_log, lambda *args: None)
     test_qapp.expected_calls[
-        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-servicevms', None)
     ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
-        + b'qubes-vm-update-restart-system' + b'\x00'
-    assert sut.restart_system_vms
+        + b'qubes-vm-update-restart-servicevms' + b'\x00'
+    assert sut.restart_service_vms
     test_qapp.expected_calls[
-        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+        ('dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-servicevms', None)
     ] = b"0\x00" + ''.encode()
-    assert not sut.restart_system_vms
+    assert not sut.restart_service_vms
     test_qapp.expected_calls[
         (
-        'dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-system', None)
+        'dom0', 'admin.vm.feature.Get', 'qubes-vm-update-restart-servicevms', None)
     ] = b'2\x00QubesFeatureNotFoundError\x00\x00' \
-            + b'qubes-vm-update-restart-system' + b'\x00'
-    assert sut.restart_system_vms
+            + b'qubes-vm-update-restart-servicevms' + b'\x00'
+    assert sut.restart_service_vms
 
 
 def test_restart_other_vms(test_qapp):
@@ -143,8 +143,8 @@ class MockCallback:
     (
         pytest.param("update-if-stale", Settings.DEFAULT_UPDATE_IF_STALE, 30,
                      "days_without_update_button"),
-        pytest.param("restart-system", Settings.DEFAULT_RESTART_SYSTEM_VMS,
-                     False, "restart_system_checkbox"),
+        pytest.param("restart-servicevms", Settings.DEFAULT_RESTART_SERVICEVMS,
+                     False, "restart_servicevms_checkbox"),
         pytest.param("restart-other", Settings.DEFAULT_RESTART_OTHER_VMS,
                      True, "restart_other_checkbox"),
     ),
@@ -222,9 +222,9 @@ def test_save(feature, default_value, new_value, test_qapp, button_name):
 
 def test_limit_concurrency(test_qapp):
     dom0_set_max_concurrency = ('dom0', 'admin.vm.feature.Set',
-                                f'qubes-vm-update-max-concurrency',)
+                                'qubes-vm-update-max-concurrency',)
     dom0_get_max_concurrency = ('dom0', 'admin.vm.feature.Get',
-                                f'qubes-vm-update-max-concurrency', None)
+                                'qubes-vm-update-max-concurrency', None)
 
     mock_log = Mock()
     sut = Settings(Gtk.Window(), test_qapp, mock_log, lambda *args: None)

--- a/qui/updater/updater_settings.py
+++ b/qui/updater/updater_settings.py
@@ -93,8 +93,8 @@ class Settings:
         )
         self.days_without_update_button.configure(adj, 1, 0)
 
-        self.restart_servicevms_checkbox: Gtk.CheckButton = self.builder.get_object(
-            "restart_servicevms")
+        self.restart_servicevms_checkbox: Gtk.CheckButton = \
+            self.builder.get_object("restart_servicevms")
         self.restart_servicevms_checkbox.connect(
             "toggled", self._show_restart_exceptions)
 
@@ -189,8 +189,10 @@ class Settings:
 
         self._init_restart_servicevms = self.restart_service_vms
         self._init_restart_other_vms = self.restart_other_vms
-        self.restart_servicevms_checkbox.set_sensitive(not self.overrides.restart)
-        self.restart_servicevms_checkbox.set_active(self._init_restart_servicevms)
+        self.restart_servicevms_checkbox.set_sensitive(
+            not self.overrides.restart)
+        self.restart_servicevms_checkbox.set_active(
+            self._init_restart_servicevms)
         self.restart_other_checkbox.set_active(self._init_restart_other_vms)
         self.restart_other_checkbox.set_sensitive(not self.overrides.restart)
 

--- a/qui/updater_settings.glade
+++ b/qui/updater_settings.glade
@@ -174,8 +174,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkCheckButton" id="restart_system">
-                        <property name="label" translatable="yes">Restart all _system qubes after update by default</property>
+                      <object class="GtkCheckButton" id="restart_servicevms">
+                        <property name="label" translatable="yes">Restart all _service qubes after update by default</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>


### PR DESCRIPTION
by default, restart servicevms instead of vms which names started with "sys-*" 
moreover the communication to a user what actually will be done is improved

fixes https://github.com/QubesOS/qubes-issues/issues/9024