### PR TITLE
Fix updater startup crash

### DIFF
--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -209,10 +209,13 @@ class IntroPage:
             output = subprocess.check_output(cmd)
             self.log.debug("Command returns: %s", output.decode())
 
+            output_lines = output.decode().split("\n")
+            if ":" not in output_lines[0]:
+                return set()
+
             return {
                 vm_name.strip() for vm_name
-                in output.decode().split("\n", maxsplit=1)[0]
-                .split(":", maxsplit=1)[1].split(",")
+                in output_lines[0].split(":", maxsplit=1)[1].split(",")
             }
         except subprocess.CalledProcessError as err:
             if err.returncode != 100:


### PR DESCRIPTION
The _get_stale_qubes function doesn't check for an empty output, which leads to a startup crash. Check if index 0 contains ":" (required for splitting) before continuing. If it doesn't, it returns an empty set.

Fixes https://github.com/QubesOS/qubes-issues/issues/9203