### PR TITLE
Monospace font for update details

### DIFF
--- a/qui/qubes-updater-base.css
+++ b/qui/qubes-updater-base.css
@@ -193,7 +193,7 @@ checkbutton check {
     padding-top: 18px;
     padding-bottom: 16px;
 
-    font-family: 'Source Sans Pro';
+    font-family: monospace;
     font-style: normal;
     font-weight: 400;
     font-size: 1em;


### PR DESCRIPTION
Changing the current `Source Sans Pro` font used for update progress detail text box to `Source Code Pro`

Reference to issue: Fixes https://github.com/QubesOS/qubes-issues/issues/9235