### PR TITLE
non interactive updater

### DIFF
--- a/locale/en/LC_MESSAGES/desktop-linux-manager.po
+++ b/locale/en/LC_MESSAGES/desktop-linux-manager.po
@@ -548,3 +548,12 @@ msgstr ""
 
 msgid "failed to update."
 msgstr ""
+
+msgid "Qubes OS is up to date."
+msgstr ""
+
+msgid "All selected qubes have been updated."
+msgstr ""
+
+msgid "There are no updates available for the selected Qubes."
+msgstr ""

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -232,11 +232,15 @@ class IntroPage:
         default_select = not any(
             (getattr(cliargs, arg)
              for arg in cliargs.non_default_select if arg != 'all'))
-        if (default_select or cliargs.all or cliargs.dom0) and (
-                cliargs.force_update
-                or bool(dom0.features.get('updates-available', False))
-                or is_stale(dom0, cliargs.update_if_stale)
-        ):
+        if ((
+            default_select and cliargs.non_interactive
+            or cliargs.all
+            or cliargs.dom0
+        ) and (
+            cliargs.force_update
+            or bool(dom0.features.get('updates-available', False))
+            or is_stale(dom0, cliargs.update_if_stale)
+        )):
             to_update.add('dom0')
 
         if cliargs.targets and "dom0" in cliargs.targets.split(","):

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -191,7 +191,7 @@ class IntroPage:
                     vms_without_dom0 = vms.difference({"dom0"})
                     if not vms_without_dom0:
                         continue
-                    value = ",".join(vms_without_dom0)
+                    value = ",".join(sorted(vms_without_dom0))
                 cmd.append(f"--{arg.replace('_', '-')}")
                 if not isinstance(value, bool):
                     cmd.append(str(value))

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -179,7 +179,8 @@ class IntroPage:
 
         args = [a for a in dir(cliargs) if not a.startswith("_")]
         for arg in args:
-            if arg in ("dom0", "no_restart", "restart", "max_concurrency",
+            if arg in ("dom0", "no_restart", "restart", "apply_to_sys",
+                       "apply_to_all", "no_apply", "max_concurrency",
                        "log", "non_interactive"):
                 continue
             value = getattr(cliargs, arg)

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -179,8 +179,8 @@ class IntroPage:
 
         args = [a for a in dir(cliargs) if not a.startswith("_")]
         for arg in args:
-            if arg in ("dom0", "no-restart", "restart", "max_concurrency",
-                       "log"):
+            if arg in ("dom0", "no_restart", "restart", "max_concurrency",
+                       "log", "non_interactive"):
                 continue
             value = getattr(cliargs, arg)
             if value:
@@ -191,8 +191,8 @@ class IntroPage:
                         continue
                     value = ",".join(vms_without_dom0)
                 cmd.append(f"--{arg.replace('_', '-')}")
-                if isinstance(value, str):
-                    cmd.append(value)
+                if isinstance(value, (str, int)):
+                    cmd.append(str(value))
 
         to_update = set()
         if cmd[2:]:

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -230,8 +230,8 @@ class IntroPage:
     @staticmethod
     def _handle_cli_dom0(dom0, to_update, cliargs):
         default_select = not any(
-            [getattr(cliargs, arg)
-             for arg in cliargs.non_default_select if arg != 'all'])
+            (getattr(cliargs, arg)
+             for arg in cliargs.non_default_select if arg != 'all'))
         if (default_select or cliargs.all or cliargs.dom0) and (
                 cliargs.force_update
                 or bool(dom0.features.get('updates-available', False))

--- a/qui/updater/intro_page.py
+++ b/qui/updater/intro_page.py
@@ -179,7 +179,7 @@ class IntroPage:
 
         args = [a for a in dir(cliargs) if not a.startswith("_")]
         for arg in args:
-            if arg in ("dom0", "no_restart", "restart", "apply_to_sys",
+            if arg in ("dom0", "restart", "apply_to_sys",
                        "apply_to_all", "no_apply", "max_concurrency",
                        "log", "non_interactive"):
                 continue
@@ -195,10 +195,7 @@ class IntroPage:
                 if isinstance(value, (str, int)):
                     cmd.append(str(value))
 
-        to_update = set()
-        if cmd[2:]:
-            to_update = self._get_stale_qubes(cmd)
-
+        to_update = self._get_stale_qubes(cmd)
         to_update = self._handle_cli_dom0(dom0, to_update, cliargs)
 
         for row in self.list_store:

--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -461,16 +461,19 @@ class ProgressPage:
         2. number of vms that tried to update but no update was found,
         3. vms that update was canceled before starting.
         """
-        vm_updated_num = len(
+        updated = len(
             [row for row in self.vms_to_update
              if row.status == UpdateStatus.Success])
-        vm_no_updates_num = len(
+        no_updates = len(
             [row for row in self.vms_to_update
              if row.status == UpdateStatus.NoUpdatesFound])
-        vm_failed_num = len(
+        failed = len(
             [row for row in self.vms_to_update
-             if row.status in (UpdateStatus.Error, UpdateStatus.Cancelled)])
-        return vm_updated_num, vm_no_updates_num, vm_failed_num
+             if row.status == UpdateStatus.Error])
+        cancelled = len(
+            [row for row in self.vms_to_update
+             if row.status == UpdateStatus.Cancelled])
+        return updated, no_updates, failed, cancelled
 
 
 class Ticker:

--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -330,6 +330,7 @@ class ProgressPage:
             ['qubes-vm-update',
              '--show-output',
              '--just-print-progress',
+             '--force-update',
              *args,
              '--targets', targets],
             stderr=subprocess.PIPE, stdout=subprocess.PIPE)

--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -44,7 +44,8 @@ class ProgressPage:
             log,
             header_label,
             next_button,
-            cancel_button
+            cancel_button,
+            callback
     ):
         self.builder = builder
         self.log = log
@@ -54,6 +55,7 @@ class ProgressPage:
         self.vms_to_update = None
         self.exit_triggered = False
         self.update_thread = None
+        self.after_update_callback = callback
 
         self.update_details = QubeUpdateDetails(self.builder)
 
@@ -127,9 +129,10 @@ class ProgressPage:
         if templs:
             self.update_templates(templs, settings)
 
-        GLib.idle_add(self.next_button.set_sensitive, True)
         GLib.idle_add(self.header_label.set_text, l("Update finished"))
         GLib.idle_add(self.cancel_button.set_visible, False)
+        GLib.idle_add(self.next_button.set_sensitive, True)
+        self.after_update_callback()
 
     def update_admin_vm(self, admins):
         """Runs command to update dom0."""

--- a/qui/updater/progress_page.py
+++ b/qui/updater/progress_page.py
@@ -381,6 +381,7 @@ class ProgressPage:
         try:
             if status == "done":
                 update_status = UpdateStatus.from_name(info)
+                GLib.idle_add(rows[name].set_update_progress, 100)
                 GLib.idle_add(rows[name].set_status, update_status)
         except KeyError:
             return

--- a/qui/updater/summary_page.py
+++ b/qui/updater/summary_page.py
@@ -251,7 +251,7 @@ class SummaryPage:
         time.sleep(0.01)
 
         if self.restart_thread.is_alive():
-            # show wainting dialog
+            # show waiting dialog
             spinner = Gtk.Spinner()
             spinner.start()
             dialog = show_dialog(None, l("Applying updates to qubes"), l(

--- a/qui/updater/tests/conftest.py
+++ b/qui/updater/tests/conftest.py
@@ -40,6 +40,10 @@ from gi.repository import Gtk
 
 @pytest.fixture
 def test_qapp():
+    return test_qapp_impl()
+
+
+def test_qapp_impl():
     """Test QubesApp"""
     qapp = QubesTest()
     qapp._local_name = 'dom0'  # pylint: disable=protected-access

--- a/qui/updater/tests/test_intro_page.py
+++ b/qui/updater/tests/test_intro_page.py
@@ -181,15 +181,18 @@ _derived_qubes = _domains.difference(_non_derived_qubes)
         # `qubes-update-gui --all`
         # Target all updatable VMs (AdminVM, TemplateVMs and StandaloneVMs)
         pytest.param(
-            ('--all',), ",".join(_tmpls_and_stndas).encode(),
-            ",".join(_derived_qubes).encode(), _non_derived_qubes, ('--all',),
+            ('--all', '--force-update'),
+            ",".join(_tmpls_and_stndas).encode(),
+            ",".join(_derived_qubes).encode(), _non_derived_qubes,
+            ('--all', '--force-update'),
             id="all"),
         # `qubes-update-gui --update-if-stale 10`
         # Target all TemplateVMs and StandaloneVMs with known updates or for
         # which last update check was more than <10> days ago.
         pytest.param(
             ('--non-interactive', '--update-if-stale', '10'),
-            b'fedora-36', b'', {'fedora-36'}, ('--update-if-stale', '10'),
+            b'fedora-36', b'', {'fedora-36', 'dom0'},
+            ('--update-if-stale', '10'),
             id="if-stale"),
         # `qubes-update-gui --targets dom0,fedora-36`
         # Comma separated list of VMs to target
@@ -205,7 +208,8 @@ _derived_qubes = _domains.difference(_non_derived_qubes)
             id="standalones"),
         # `qubes-update-gui --dom0`
         # Target dom0
-        pytest.param(('--dom0',), b'', b'', {'dom0'}, None, id="dom0"),
+        pytest.param(('--dom0', '--force-update'), b'', b'', {'dom0'},
+                     None, id="dom0"),
         # `qubes-update-gui --dom0 --skip dom0`
         # Comma separated list of VMs to be skipped,
         # works with all other options.

--- a/qui/updater/tests/test_intro_page.py
+++ b/qui/updater/tests/test_intro_page.py
@@ -264,7 +264,7 @@ def test_select_rows_ignoring_conditions(
         result += b'Following qubes will be updated: ' + derived_qubes
     mock_subprocess.return_value = result
 
-    cliargs = parse_args(args)
+    cliargs = parse_args(args, test_qapp)
     sut.select_rows_ignoring_conditions(cliargs, test_qapp.domains['dom0'])
     to_update = {row.name for row in sut.list_store if row.selected}
 

--- a/qui/updater/tests/test_progress_page.py
+++ b/qui/updater/tests/test_progress_page.py
@@ -233,6 +233,7 @@ def test_do_update_templates(
         ['qubes-vm-update',
          '--show-output',
          '--just-print-progress',
+         '--force-update',
          '--targets',
          'fedora-35,fedora-36,test-standalone'],
         stderr=subprocess.PIPE, stdout=subprocess.PIPE)]

--- a/qui/updater/tests/test_progress_page.py
+++ b/qui/updater/tests/test_progress_page.py
@@ -258,11 +258,12 @@ def test_get_update_summary(
 
     sut.vms_to_update = updatable_vms_list
 
-    vm_updated_num, vm_no_updates_num, vm_failed_num = sut.get_update_summary()
+    updated, no_updates, failed, cancelled = sut.get_update_summary()
 
-    assert vm_updated_num == 1
-    assert vm_no_updates_num == 1
-    assert vm_failed_num == 2
+    assert updated == 1
+    assert no_updates == 1
+    assert failed == 1
+    assert cancelled == 1
     mock_callback.assert_not_called()
 
 

--- a/qui/updater/tests/test_progress_page.py
+++ b/qui/updater/tests/test_progress_page.py
@@ -43,8 +43,10 @@ def test_init_update(
 
     mock_threading.return_value = mock_thread
     mock_log = Mock()
+    mock_callback = Mock()
     sut = ProgressPage(
-        real_builder, mock_log, mock_label, mock_next_button, mock_cancel_button
+        real_builder, mock_log, mock_label, mock_next_button,
+        mock_cancel_button, mock_callback
     )
 
     sut.progress_list = mock_tree_view
@@ -61,6 +63,7 @@ def test_init_update(
     assert mock_label.halign == Gtk.Align.CENTER
 
     assert sut.progress_list.model == all_vms_list.list_store_raw
+    mock_callback.assert_not_called()
 
 
 @patch('gi.repository.GLib.idle_add')
@@ -69,8 +72,10 @@ def test_perform_update(
         mock_next_button, mock_cancel_button, mock_label, updatable_vms_list
 ):
     mock_log = Mock()
+    mock_callback = Mock()
     sut = ProgressPage(
-        real_builder, mock_log, mock_label, mock_next_button, mock_cancel_button
+        real_builder, mock_log, mock_label, mock_next_button,
+        mock_cancel_button, mock_callback
     )
 
     sut.vms_to_update = updatable_vms_list
@@ -91,6 +96,7 @@ def test_perform_update(
              call(mock_label.set_text, "Update finished"),
              call(mock_cancel_button.set_visible, False)]
     idle_add.assert_has_calls(calls, any_order=True)
+    mock_callback.assert_called_once()
 
 
 @patch('gi.repository.GLib.idle_add')
@@ -108,8 +114,10 @@ def test_update_admin_vm(
         mock_list_store
 ):
     mock_log = Mock()
+    mock_callback = Mock()
     sut = ProgressPage(
-        real_builder, mock_log, mock_label, mock_next_button, mock_cancel_button
+        real_builder, mock_log, mock_label, mock_next_button,
+        mock_cancel_button, mock_callback
     )
 
     admins = ListWrapper(UpdateRowWrapper, mock_list_store)
@@ -130,6 +138,7 @@ def test_update_admin_vm(
     idle_add.assert_has_calls(calls)
     if not interrupted:
         mock_subprocess.assert_called()
+    mock_callback.assert_not_called()
 
 
 @patch('gi.repository.GLib.idle_add')
@@ -145,8 +154,10 @@ def test_update_templates(
         mock_next_button, mock_cancel_button, mock_label, mock_text_view
 ):
     mock_log = Mock()
+    mock_callback = Mock()
     sut = ProgressPage(
-        real_builder, mock_log, mock_label, mock_next_button, mock_cancel_button
+        real_builder, mock_log, mock_label, mock_next_button,
+        mock_cancel_button, mock_callback
     )
 
     sut.do_update_templates = Mock()
@@ -172,6 +183,7 @@ def test_update_templates(
     idle_add.assert_has_calls(calls, any_order=True)
     if not interrupted:
         sut.do_update_templates.assert_called()
+    mock_callback.assert_not_called()
 
 
 @patch('subprocess.Popen')
@@ -200,8 +212,10 @@ def test_do_update_templates(
     mock_subprocess.return_value = MockPorc()
 
     mock_log = Mock()
+    mock_callback = Mock()
     sut = ProgressPage(
-        real_builder, mock_log, mock_label, mock_next_button, mock_cancel_button
+        real_builder, mock_log, mock_label, mock_next_button,
+        mock_cancel_button, mock_callback
     )
     sut.read_stderrs = lambda *_args, **_kwargs: None
     sut.read_stdouts = lambda *_args, **_kwargs: None
@@ -223,6 +237,7 @@ def test_do_update_templates(
          'fedora-35,fedora-36,test-standalone'],
         stderr=subprocess.PIPE, stdout=subprocess.PIPE)]
     mock_subprocess.assert_has_calls(calls)
+    mock_callback.assert_not_called()
 
 
 def test_get_update_summary(
@@ -230,8 +245,10 @@ def test_get_update_summary(
         mock_next_button, mock_cancel_button, mock_label, updatable_vms_list
 ):
     mock_log = Mock()
+    mock_callback = Mock()
     sut = ProgressPage(
-        real_builder, mock_log, mock_label, mock_next_button, mock_cancel_button
+        real_builder, mock_log, mock_label, mock_next_button,
+        mock_cancel_button, mock_callback
     )
 
     updatable_vms_list[0].set_status(UpdateStatus.NoUpdatesFound)
@@ -246,6 +263,7 @@ def test_get_update_summary(
     assert vm_updated_num == 1
     assert vm_no_updates_num == 1
     assert vm_failed_num == 2
+    mock_callback.assert_not_called()
 
 
 def test_set_active_row(real_builder, updatable_vms_list):

--- a/qui/updater/tests/test_summary_page.py
+++ b/qui/updater/tests/test_summary_page.py
@@ -212,7 +212,7 @@ def test_populate_restart_list(
     "alive_requests_max, status",
     (pytest.param(3, RestartStatus.OK),
      pytest.param(0, RestartStatus.OK),
-     pytest.param(1, RestartStatus.ERROR),
+     pytest.param(1, RestartStatus.ERROR_TMPL_DOWN),
      pytest.param(1, RestartStatus.NOTHING_TO_DO),
      ),
 )
@@ -259,7 +259,7 @@ def test_restart_selected_vms(
     sut.status = status
 
     # ACT
-    sut.restart_selected_vms()
+    sut.restart_selected_vms(show_only_error=False)
 
     # ASSERT
 
@@ -288,7 +288,7 @@ def test_restart_selected_vms(
             calls = [call(None, "Success",
                           "All qubes were restarted/shutdown successfully.",
                           RESPONSES_OK, icon)]
-        if status == RestartStatus.ERROR:
+        if status.is_error():
             calls = [call(None, "Failure",
                           "During restarting following errors occurs: " + sut.err,
                           RESPONSES_OK, icon)]

--- a/qui/updater/tests/test_updater.py
+++ b/qui/updater/tests/test_updater.py
@@ -29,7 +29,7 @@ from qui.updater.updater import QubesUpdater, parse_args
 @patch('logging.getLogger')
 @patch('qui.updater.intro_page.IntroPage.populate_vm_list')
 def test_setup(populate_vm_list, _mock_logging, __mock_logging, test_qapp):
-    sut = QubesUpdater(test_qapp, parse_args(()))
+    sut = QubesUpdater(test_qapp, parse_args((), test_qapp))
     sut.perform_setup()
     calls = [call(sut.qapp, sut.settings)]
     populate_vm_list.assert_has_calls(calls)
@@ -53,7 +53,7 @@ def test_setup(populate_vm_list, _mock_logging, __mock_logging, test_qapp):
 )
 def test_retcode(_populate_vm_list, _mock_logging, __mock_logging,
                  update_results, ret_code, test_qapp):
-    sut = QubesUpdater(test_qapp, parse_args(()))
+    sut = QubesUpdater(test_qapp, parse_args((), test_qapp))
     sut.perform_setup()
 
     sut.intro_page.get_vms_to_update = Mock()

--- a/qui/updater/tests/test_updater.py
+++ b/qui/updater/tests/test_updater.py
@@ -41,14 +41,16 @@ def test_setup(populate_vm_list, _mock_logging, __mock_logging, test_qapp):
 @pytest.mark.parametrize(
     "update_results, ret_code",
     (
-        pytest.param((0, 0, 0), 100, id="nothing to do"),
-        pytest.param((0, 0, 1), 1, id="failed"),
-        pytest.param((0, 1, 0), 100, id="no updates"),
-        pytest.param((0, 1, 1), 1, id="no updates + failed"),
-        pytest.param((1, 0, 0), 0, id="success"),
-        pytest.param((1, 0, 1), 1, id="success + failed"),
-        pytest.param((1, 1, 0), 0, id="success + no updated"),
-        pytest.param((1, 1, 1), 1, id="all"),
+        pytest.param((0, 0, 0, 0), 100, id="nothing to do"),
+        pytest.param((0, 0, 1, 0), 1, id="failed"),
+        pytest.param((0, 0, 0, 1), 130, id="cancelled"),
+        pytest.param((0, 0, 1, 1), 130, id="failed + cancelled"),
+        pytest.param((0, 1, 0, 0), 100, id="no updates"),
+        pytest.param((0, 1, 1, 0), 1, id="no updates + failed"),
+        pytest.param((1, 0, 0, 0), 0, id="success"),
+        pytest.param((1, 0, 1, 0), 1, id="success + failed"),
+        pytest.param((1, 1, 0, 0), 0, id="success + no updated"),
+        pytest.param((1, 1, 1, 1), 130, id="all"),
     )
 )
 def test_retcode(_populate_vm_list, _mock_logging, __mock_logging,
@@ -86,4 +88,6 @@ def test_retcode(_populate_vm_list, _mock_logging, __mock_logging,
     sut.summary_page.populate_restart_list.assert_called_once_with(
         restart=True, vm_updated=vms_to_update, settings=sut.settings)
     assert sut.retcode == ret_code
-    sut.summary_page.show.assert_called_once_with(*update_results)
+    expected_summary = (update_results[0], update_results[1],
+                        update_results[2] + update_results[3])
+    sut.summary_page.show.assert_called_once_with(*expected_summary)

--- a/qui/updater/tests/test_updater.py
+++ b/qui/updater/tests/test_updater.py
@@ -18,7 +18,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 # USA.
-from unittest.mock import patch, call
+from unittest.mock import patch, call, Mock
+
+import pytest
 
 from qui.updater.updater import QubesUpdater, parse_args
 
@@ -31,3 +33,57 @@ def test_setup(populate_vm_list, _mock_logging, __mock_logging, test_qapp):
     sut.perform_setup()
     calls = [call(sut.qapp, sut.settings)]
     populate_vm_list.assert_has_calls(calls)
+
+
+@patch('logging.FileHandler')
+@patch('logging.getLogger')
+@patch('qui.updater.intro_page.IntroPage.populate_vm_list')
+@pytest.mark.parametrize(
+    "update_results, ret_code",
+    (
+        pytest.param((0, 0, 0), 100, id="nothing to do"),
+        pytest.param((0, 0, 1), 1, id="failed"),
+        pytest.param((0, 1, 0), 100, id="no updates"),
+        pytest.param((0, 1, 1), 1, id="no updates + failed"),
+        pytest.param((1, 0, 0), 0, id="success"),
+        pytest.param((1, 0, 1), 1, id="success + failed"),
+        pytest.param((1, 1, 0), 0, id="success + no updated"),
+        pytest.param((1, 1, 1), 1, id="all"),
+    )
+)
+def test_retcode(_populate_vm_list, _mock_logging, __mock_logging,
+                 update_results, ret_code, test_qapp):
+    sut = QubesUpdater(test_qapp, parse_args(()))
+    sut.perform_setup()
+
+    sut.intro_page.get_vms_to_update = Mock()
+    vms_to_update = Mock()
+    sut.intro_page.get_vms_to_update.return_value = vms_to_update
+
+    def set_vms(_vms_to_update, _settings):
+        sut.progress_page.vms_to_update = _vms_to_update
+    sut.progress_page.init_update = Mock(side_effect=set_vms)
+
+    sut.next_clicked(None)
+
+    assert not sut.intro_page.active
+    assert sut.progress_page.is_visible
+    sut.progress_page.init_update.assert_called_once_with(
+        vms_to_update, sut.settings)
+
+    # set sut.summary_page.is_populated = False
+    sut.summary_page.list_store = None
+    def populate(**_kwargs):
+        sut.summary_page.list_store = []
+    sut.summary_page.populate_restart_list = Mock(side_effect=populate)
+    sut.progress_page.get_update_summary = Mock()
+    sut.progress_page.get_update_summary.return_value = update_results
+    sut.summary_page.show = Mock()
+    sut.summary_page.show.return_value = None
+
+    sut.next_clicked(None)
+
+    sut.summary_page.populate_restart_list.assert_called_once_with(
+        restart=True, vm_updated=vms_to_update, settings=sut.settings)
+    assert sut.retcode == ret_code
+    sut.summary_page.show.assert_called_once_with(*update_results)

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -29,6 +29,10 @@ locale.bindtextdomain("desktop-linux-manager", "/usr/locales/")
 locale.textdomain('desktop-linux-manager')
 
 
+class ArgumentError(Exception):
+    """Nonsense arguments"""
+
+
 class QubesUpdater(Gtk.Application):
     # pylint: disable=too-many-instance-attributes
 
@@ -126,7 +130,7 @@ class QubesUpdater(Gtk.Application):
         if self.cliargs.apply_to_all:
             overridden_apply_to_sys = True
             overridden_apply_to_other = True
-        elif self.cliargs.restart:
+        elif self.cliargs.apply_to_sys:
             overridden_apply_to_sys = True
         elif self.cliargs.no_apply:
             overridden_apply_to_sys = False
@@ -182,6 +186,15 @@ class QubesUpdater(Gtk.Application):
                 return
             self.next_clicked(None, skip_intro=True)
         else:
+            # default update_if_stale -> do nothing
+            if self.cliargs.update_if_available:
+                self.intro_page.head_checkbox.state = (
+                    self.intro_page.head_checkbox.SAFE)
+                self.intro_page.select_rows()
+            elif self.cliargs.force_update:
+                self.intro_page.head_checkbox.state = (
+                    self.intro_page.head_checkbox.ALL)
+                self.intro_page.select_rows()
             self.log.info("Show intro page.")
         self.main_window.show_all()
         width = self.intro_page.vm_list.get_preferred_width().natural_width
@@ -239,8 +252,16 @@ class QubesUpdater(Gtk.Application):
         In the case of non-interactive mode or if there is nothing to do,
         we should show some feedback to the user.
         """
-        if (not self.cliargs.skip and not self.cliargs.targets
-                and self.retcode in (0, 100)):
+        non_default_select = any(
+            [getattr(self.cliargs, arg)
+             for arg in self.cliargs.non_default_select if arg != 'all'])
+        if (
+                (  # at least all vms with available updates was updated
+                (self.cliargs.all and not self.cliargs.skip)
+                or not non_default_select
+                )
+                and self.retcode in (0, 100)
+        ):
             msg = "Qubes OS is up to date."
         elif self.retcode == 0:
             msg = "All selected qubes have been updated."
@@ -301,63 +322,95 @@ class QubesUpdater(Gtk.Application):
 
 def parse_args(args):
     parser = argparse.ArgumentParser()
+    default_update_if_stale = 7
 
     parser.add_argument('--log', action='store', default='WARNING',
                         help='Provide logging level. Values: DEBUG, INFO, '
                              'WARNING (default), ERROR, CRITICAL')
+
     parser.add_argument('--max-concurrency', action='store',
                         help='Maximum number of VMs configured simultaneously '
                              '(default: number of cpus)',
                         type=int)
-    restart_gr = parser.add_mutually_exclusive_group()
-    restart_gr.add_argument('--restart', '--apply-to-sys', '-r',
-                            action='store_true',
-                            help='Restart Service VMs whose template '
-                                 'has been updated.')
-    restart_gr.add_argument('--apply-to-all', '-R',
-                            action='store_true',
-                            help='Restart Service VMs and shutdown AppVMs '
-                                 'whose template has been updated.')
-    restart_gr.add_argument('--no-apply', action='store_true',
-                            help='Do not restart/shutdown any AppVMs.')
 
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('--targets', action='store',
-                       help='Comma separated list of VMs to target')
-    group.add_argument('--all', action='store_true',
-                       help='Target all updatable VMs (AdminVM, '
-                            'TemplateVMs and StandaloneVMs)')
-    group.add_argument('--update-if-stale', action='store',
-                       help='Target all TemplateVMs and StandaloneVMs with '
-                            'known updates or for which last update check was '
-                            'more than N days ago.',
-                       type=int)
+    restart = parser.add_mutually_exclusive_group()
+    restart.add_argument(
+        '--apply-to-sys', '--restart', '-r',
+        action='store_true',
+        help='Restart not updated ServiceVMs whose template has been updated.')
+    restart.add_argument(
+        '--apply-to-all', '-R', action='store_true',
+        help='Restart not updated ServiceVMs and shutdown not updated AppVMs '
+             'whose template has been updated.')
+    restart.add_argument(
+        '--no-apply', action='store_true',
+        help='DEFAULT. Do not restart/shutdown any AppVMs.')
 
-    parser.add_argument('--skip', action='store',
-                        help='Comma separated list of VMs to be skipped, '
-                             'works with all other options.', default="")
-    parser.add_argument('--templates', action='store_true',
-                        help='Target all TemplatesVMs')
-    parser.add_argument('--standalones', action='store_true',
-                        help='Target all StandaloneVMs')
-    parser.add_argument('--dom0', action='store_true',
-                        help='Target dom0')
+    update_state = parser.add_mutually_exclusive_group()
+    update_state.add_argument(
+        '--force-update', action='store_true',
+        help='Attempt to update all targeted VMs '
+             'even if no updates are available')
+    update_state.add_argument(
+        '--update-if-stale', action='store',
+        help='DEFAULT. '
+             'Attempt to update targeted VMs with known updates available '
+             'or for which last update check was more than N days ago. '
+             '(default: %(default)d)',
+        type=int, default=default_update_if_stale)
+    update_state.add_argument(
+        '--update-if-available', action='store_true',
+        help='Update targeted VMs with known updates available.')
 
-    parser.add_argument('--non-interactive', action='store_true',
+    parser.add_argument(
+        '--skip', action='store',
+        help='Comma separated list of VMs to be skipped, '
+             'works with all other options. '
+             'If present, skip manual selection of qubes to update.',
+        default="")
+    parser.add_argument(
+        '--targets', action='store',
+        help='Comma separated list of updatable VMs to target. '
+             'If present, skip manual selection of qubes to update.')
+    parser.add_argument(
+        '--templates', '-T', action='store_true',
+        help='Target all updatable TemplateVMs. '
+             'If present, skip manual selection of qubes to update.')
+    parser.add_argument(
+        '--standalones', '-S', action='store_true',
+        help='Target all updatable StandaloneVMs. '
+             'If present, skip manual selection of qubes to update.')
+    parser.add_argument(
+        '--all', action='store_true',
+        help='DEFAULT. Target AdminVM, TemplateVMs and StandaloneVMs.'
+             'Use explicitly with "--targets" to include both. '
+             'If explicitly present, skip manual selection of qubes to update.')
+    parser.add_argument(
+        '--dom0', action='store_true', help='Target dom0. '
+        'If present, skip manual selection of qubes to update.')
+
+    parser.add_argument('--non-interactive', '-n', action='store_true',
                         help='Run the updater GUI in non-interactive mode. '
                              'Interaction will be required in the event '
                              'of an update error.')
 
     args = parser.parse_args(args)
 
+    args.non_default_select = {
+        'skip', 'targets', 'templates', 'standalones', 'all', 'dom0'}
+
+    if args.update_if_stale < 0:
+        raise ArgumentError("Wrong value for --update-if-stale")
+    if args.update_if_stale == default_update_if_stale:
+        args.update_if_stale = None
+
     return args
 
 
 def skip_intro_if_args(args):
-    return args is not None and (args.templates or args.standalones or args.skip
-                                 or args.update_if_stale or args.all
-                                 or args.targets or args.dom0
-                                 or args.non_interactive)
+    auto_select = [getattr(args, arg) for arg in args.non_default_select
+                   ] + [args.non_interactive]
+    return any(auto_select)
 
 
 def main(args=None):

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -345,6 +345,10 @@ def parse_args(args, app):
                         help='Maximum number of VMs configured simultaneously '
                              '(default: number of cpus)',
                         type=int)
+    parser.add_argument(
+        '--signal-no-updates', action='store_true',
+        help='Return exit code 100 instread of 0 '
+             'if there is no updates available.')
 
     restart = parser.add_mutually_exclusive_group()
     restart.add_argument(
@@ -431,6 +435,8 @@ def main(args=None):
     cliargs = parse_args(args, qapp)
     app = QubesUpdater(qapp, cliargs)
     app.run()
+    if app.retcode == 100 and not app.cliargs.signal_no_updates:
+        app.retcode = 0
     sys.exit(app.retcode)
 
 

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -65,12 +65,7 @@ class QubesUpdater(Gtk.Application):
         else:
             self.log.debug("Secondary activation")
             if self.do_nothing:
-                show_dialog_with_icon(
-                    None, l("Quit"),
-                    l("Nothing to do."),
-                    buttons=RESPONSES_OK,
-                    icon_name="check_yes"
-                )
+                self._show_final_dialog()
                 self.window_close()
             else:
                 self.main_window.present()
@@ -221,7 +216,8 @@ class QubesUpdater(Gtk.Application):
                 self.summary_page.show(updated, no_updates, failed)
             else:
                 self._restart_phase()
-                self._show_final_dialog()
+                if self.cliargs.non_interactive:
+                    self._show_final_dialog()
         elif self.summary_page.is_visible:
             self._restart_phase()
 
@@ -238,12 +234,11 @@ class QubesUpdater(Gtk.Application):
 
     def _show_final_dialog(self):
         """
-        In a non-interactive mode, we should show the user a success
-        confirmation.
-        """
-        if not self.cliargs.non_interactive:
-            return
+        We should show the user a success confirmation.
 
+        In the case of non-interactive mode or if there is nothing to do,
+        we should show some feedback to the user.
+        """
         if (not self.cliargs.skip and not self.cliargs.targets
                 and self.retcode in (0, 100)):
             msg = "Qubes OS is up to date."

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -219,15 +219,17 @@ class QubesUpdater(Gtk.Application):
                     vm_updated=self.progress_page.vms_to_update,
                     settings=self.settings
                 )
-            updated, no_updates, failed = (
+            updated, no_updates, failed, cancelled = (
                 self.progress_page.get_update_summary())
-            if failed:
-                self.retcode = 1
-            if updated == 0 and failed == 0:
+            if updated == 0:
                 # no updates
                 self.retcode = 100
+            if failed:
+                self.retcode = 1
+            if cancelled:
+                self.retcode = 130
             if failed or not self.cliargs.non_interactive:
-                self.summary_page.show(updated, no_updates, failed)
+                self.summary_page.show(updated, no_updates, failed + cancelled)
             else:
                 self._restart_phase()
                 if self.cliargs.non_interactive:

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -13,7 +13,7 @@ from qubes_config.widgets.gtk_utils import load_icon_at_gtk_size, load_theme, \
     show_dialog_with_icon, RESPONSES_OK
 from qui.updater.progress_page import ProgressPage
 from qui.updater.updater_settings import Settings, OverriddenSettings
-from qui.updater.summary_page import SummaryPage, RestartStatus
+from qui.updater.summary_page import SummaryPage
 from qui.updater.intro_page import IntroPage
 
 gi.require_version('Gtk', '3.0')  # isort:skip

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -12,7 +12,7 @@ import gi  # isort:skip
 from qubes_config.widgets.gtk_utils import load_icon_at_gtk_size, load_theme, \
     show_dialog_with_icon, RESPONSES_OK
 from qui.updater.progress_page import ProgressPage
-from qui.updater.updater_settings import Settings, OverridenSettings
+from qui.updater.updater_settings import Settings, OverriddenSettings
 from qui.updater.summary_page import SummaryPage, RestartStatus
 from qui.updater.intro_page import IntroPage
 
@@ -137,7 +137,7 @@ class QubesUpdater(Gtk.Application):
             overridden_apply_to_sys = False
             overridden_apply_to_other = False
 
-        overrides = OverridenSettings(
+        overrides = OverriddenSettings(
             apply_to_sys=overridden_apply_to_sys,
             apply_to_other=overridden_apply_to_other,
             max_concurrency=self.cliargs.max_concurrency,
@@ -214,6 +214,9 @@ class QubesUpdater(Gtk.Application):
                 self.progress_page.get_update_summary())
             if failed:
                 self.retcode = 1
+            if updated == 0 and failed == 0:
+                # no updates
+                self.retcode = 100
             if failed or not self.cliargs.non_interactive:
                 self.summary_page.show(updated, no_updates, failed)
             else:

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -256,8 +256,9 @@ class QubesUpdater(Gtk.Application):
         we should show some feedback to the user.
         """
         non_default_select = any(
-            [getattr(self.cliargs, arg)
-             for arg in self.cliargs.non_default_select if arg != 'all'])
+            (getattr(self.cliargs, arg)
+             for arg in self.cliargs.non_default_select if arg != 'all'))
+        msg = "Nothing to do."
         if (
                 (  # at least all vms with available updates was updated
                 (self.cliargs.all and not self.cliargs.skip)

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -133,7 +133,7 @@ class QubesUpdater(Gtk.Application):
             overridden_apply_to_other = True
         elif self.cliargs.restart:
             overridden_apply_to_sys = True
-        elif self.cliargs.no_restart:
+        elif self.cliargs.no_apply:
             overridden_apply_to_sys = False
             overridden_apply_to_other = False
 

--- a/qui/updater/updater_settings.py
+++ b/qui/updater/updater_settings.py
@@ -195,11 +195,12 @@ class Settings:
         self._init_restart_servicevms = self.restart_service_vms
         self._init_restart_other_vms = self.restart_other_vms
         self.restart_servicevms_checkbox.set_sensitive(
-            not self.overrides.restart)
+            not self.overrides.apply_to_sys)
         self.restart_servicevms_checkbox.set_active(
             self._init_restart_servicevms)
         self.restart_other_checkbox.set_active(self._init_restart_other_vms)
-        self.restart_other_checkbox.set_sensitive(not self.overrides.restart)
+        self.restart_other_checkbox.set_sensitive(
+            not self.overrides.apply_to_other)
 
         self._init_max_concurrency = self.max_concurrency
         self._init_limit_concurrency = self._init_max_concurrency is not None

--- a/qui/updater/updater_settings.py
+++ b/qui/updater/updater_settings.py
@@ -39,7 +39,8 @@ GObject.signal_new('child-removed',
 
 @dataclasses.dataclass(frozen=True)
 class OverridenSettings:
-    restart: Optional[bool] = None
+    apply_to_sys: Optional[bool] = None
+    apply_to_other: Optional[bool] = None
     max_concurrency: Optional[int] = None
     update_if_stale: Optional[int] = None
 
@@ -148,8 +149,8 @@ class Settings:
     @property
     def restart_service_vms(self) -> bool:
         """Return the current (set by this window or manually) option value."""
-        if self.overrides.restart is not None:
-            return self.overrides.restart
+        if self.overrides.apply_to_sys is not None:
+            return self.overrides.apply_to_sys
 
         result = get_boolean_feature(
             self.vm, "qubes-vm-update-restart-servicevms",
@@ -168,8 +169,8 @@ class Settings:
     @property
     def restart_other_vms(self) -> bool:
         """Return the current (set by this window or manually) option value."""
-        if self.overrides.restart is not None:
-            return self.overrides.restart
+        if self.overrides.apply_to_other is not None:
+            return self.overrides.apply_to_other
         return get_boolean_feature(
             self.vm, "qubes-vm-update-restart-other",
             Settings.DEFAULT_RESTART_OTHER_VMS)

--- a/qui/updater/updater_settings.py
+++ b/qui/updater/updater_settings.py
@@ -37,8 +37,9 @@ GObject.signal_new('child-removed',
                    GObject.SignalFlags.RUN_LAST, GObject.TYPE_PYOBJECT,
                    (GObject.TYPE_PYOBJECT,))
 
+
 @dataclasses.dataclass(frozen=True)
-class OverridenSettings:
+class OverriddenSettings:
     apply_to_sys: Optional[bool] = None
     apply_to_other: Optional[bool] = None
     max_concurrency: Optional[int] = None
@@ -59,7 +60,7 @@ class Settings:
             qapp,
             log,
             refresh_callback: Callable,
-            overrides: OverridenSettings = OverridenSettings(),
+            overrides: OverriddenSettings = OverriddenSettings(),
     ):
         self.qapp = qapp
         self.log = log
@@ -71,7 +72,7 @@ class Settings:
         self.builder.set_translation_domain("desktop-linux-manager")
 
         glade_ref = (importlib.resources.files('qui') /
-                      'updater_settings.glade')
+                     'updater_settings.glade')
         with importlib.resources.as_file(glade_ref) as path:
             self.builder.add_from_file(str(path))
 
@@ -222,7 +223,7 @@ class Settings:
         )
 
     def show(self):
-        """Show hidden window."""
+        """Show a hidden window."""
         self.load_settings()
         self.settings_window.show_all()
         self._show_restart_exceptions()


### PR DESCRIPTION
This PR is a general solution to several issues, particularly related to the use of CLI arguments. 
It implements the return of non-zero codes when an update fails, is canceled, or when no new updates are available. 
CLI arguments have been unified with the backend to make their usage easier. 
The reason for this PR is distinguishing between situations when we can confirm that the system is fully updated and when it is only partially updated.

depends on QubesOS/qubes-core-admin-linux/pull/157

fixes https://github.com/QubesOS/qubes-issues/issues/9014
fixes https://github.com/QubesOS/qubes-issues/issues/9032
fixes https://github.com/QubesOS/qubes-issues/issues/9225