### PR TITLE
Help text in policy editor is wrapped to too wide size

### DIFF
--- a/qubes_config/policy_editor.glade
+++ b/qubes_config/policy_editor.glade
@@ -40,7 +40,6 @@
     </child>
   </object>
   <object class="GtkApplicationWindow" id="main_window">
-    <property name="height-request">700</property>
     <property name="can-focus">False</property>
     <property name="hexpand">False</property>
     <property name="vexpand">False</property>
@@ -103,7 +102,7 @@
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="source_window">
-                        <property name="width-request">800</property>
+                        <property name="width-request">750</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="vexpand">True</property>
@@ -153,7 +152,7 @@
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="help_window">
-                    <property name="width-request">450</property>
+                    <property name="width-request">270</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="shadow-type">in</property>
@@ -178,7 +177,7 @@
                   </object>
                   <packing>
                     <property name="resize">True</property>
-                    <property name="shrink">True</property>
+                    <property name="shrink">False</property>
                   </packing>
                 </child>
               </object>

--- a/qubes_config/policy_editor.glade
+++ b/qubes_config/policy_editor.glade
@@ -40,7 +40,7 @@
     </child>
   </object>
   <object class="GtkApplicationWindow" id="main_window">
-    <property name="height-request">800</property>
+    <property name="height-request">700</property>
     <property name="can-focus">False</property>
     <property name="hexpand">False</property>
     <property name="vexpand">False</property>
@@ -103,7 +103,7 @@
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="source_window">
-                        <property name="width-request">1000</property>
+                        <property name="width-request">800</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="vexpand">True</property>
@@ -147,13 +147,13 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="resize">False</property>
-                    <property name="shrink">True</property>
+                    <property name="resize">True</property>
+                    <property name="shrink">False</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow" id="help_window">
-                    <property name="width-request">500</property>
+                    <property name="width-request">450</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="shadow-type">in</property>
@@ -161,6 +161,7 @@
                       <object class="GtkViewport" id="help_viewport">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="border_width">5</property>
                         <child>
                           <object class="GtkLabel" id="help_label">
                             <property name="visible">True</property>

--- a/qubes_config/policy_editor/policy_editor.py
+++ b/qubes_config/policy_editor/policy_editor.py
@@ -184,6 +184,16 @@ class PolicyEditor(Gtk.Application):
         self.main_window : Gtk.ApplicationWindow = \
             self.builder.get_object('main_window')
 
+        # Reserving 3 pixels for window border on all sides (most themes use 2)
+        # Reserving 32x2 pixels for taskbar (default on top) and Window title.
+        # Setting minimum supported size
+        self.main_window.set_size_request(1024 - 3*2, 768 - 3*2 - 32*2)
+        width = min(1920, self.main_window.get_screen().get_width())
+        height= min(1280, self.main_window.get_screen().get_height())
+        self.main_window.set_default_size(width - 3*2, height - 3*2 - 32*2)
+        # ToDo: Considering maximizing by default as it packs too much info.
+        # self.main_window.maximize()
+
         # setup source and help
         header_box: Gtk.Box = self.builder.get_object('header_box')
         self.header_view = GtkSource.View()


### PR DESCRIPTION
Fixes: https://github.com/QubesOS/qubes-issues/issues/9060