### PR TITLE
Fix removing VM from obsolete_vms

### DIFF
--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -170,8 +170,8 @@ class UpdatesTray(Gtk.Application):
         if vm in self.vms_needing_update:
             self.vms_needing_update.remove(vm)
             self.update_indicator_state()
-        if vm.name in self.obsolete_vms:
-            self.obsolete_vms.remove(vm.name)
+        if vm in self.obsolete_vms:
+            self.obsolete_vms.remove(vm)
             self.update_indicator_state()
 
     def feature_unset(self, vm, event, feature, **_kwargs):


### PR DESCRIPTION
The domain-delete event gets string as a 'vm' argument, so use it
directly instead of accessing its 'name' attribute.

Fixes: 25f1be1 "Remove VM from obsolete_vms list if template is deleted"