### PR TITLE
Fix handling domain-add event in qui-updates

### DIFF
--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -147,9 +147,9 @@ class UpdatesTray(Gtk.Application):
         self.dispatcher.add_handler('domain-feature-set:os-eol',
                                     self.feature_change)
 
-    def domain_added(self, _submitter, _event, vmname, *_args, **_kwargs):
+    def domain_added(self, _submitter, _event, vm, *_args, **_kwargs):
         try:
-            vm = self.qapp.domains[vmname]
+            vm = self.qapp.domains[vm]
         except exc.QubesDaemonCommunicationError:
             return
         except exc.QubesException:


### PR DESCRIPTION
Event handlers are called with keyword arguments, so "vm" needs to
remain "vm".

Fixes: a3f61ca "Do not notify outdated & EOL VMs if `skip-update` set"