### PR TITLE
Improve colors on selected updater row

### DIFF
--- a/qui/qubes-updater-base.css
+++ b/qui/qubes-updater-base.css
@@ -229,6 +229,10 @@ treeview.view button
   color: @text-color;
 }
 
+treeview.view:selected {
+    background-color: #99bfff;
+}
+
 .add_label {
     color: @qubes-blue;
     font-weight: bold;


### PR DESCRIPTION
Pick a lighter blue, so both dark, light, and colorful (from the qube name column) text will be more visible.

fixes QubesOS/qubes-issues#8949