### PR TITLE
Show progress bar after loading CSS theme

### DIFF
--- a/qubes_config/global_config/global_config.py
+++ b/qubes_config/global_config/global_config.py
@@ -248,9 +248,6 @@ class GlobalConfig(Gtk.Application):
         """
         The function that performs actual widget realization and setup.
         """
-        self.progress_bar_dialog.show()
-        self.progress_bar_dialog.update_progress(0)
-
         self.builder = Gtk.Builder()
         glade_ref = (importlib.resources.files('qubes_config') /
                      'global_config.glade')
@@ -265,6 +262,9 @@ class GlobalConfig(Gtk.Application):
                    package_name='qubes_config',
                    light_file_name='qubes-global-config-light.css',
                    dark_file_name='qubes-global-config-dark.css')
+
+        self.progress_bar_dialog.show_all()
+        self.progress_bar_dialog.update_progress(0)
 
         self.apply_button: Gtk.Button = self.builder.get_object('apply_button')
         self.cancel_button: Gtk.Button = \

--- a/qubes_config/new_qube/new_qube_app.py
+++ b/qubes_config/new_qube/new_qube_app.py
@@ -89,9 +89,6 @@ class CreateNewQube(Gtk.Application):
         The function that performs actual widget realization and setup. Should
         be only called once, in the main instance of this application.
         """
-        self.progress_bar_dialog.show()
-        self.progress_bar_dialog.update_progress(0.1)
-
         self.builder = Gtk.Builder()
         glade_ref = (importlib.resources.files('qubes_config') /
                      'new_qube.glade')
@@ -108,6 +105,7 @@ class CreateNewQube(Gtk.Application):
                    light_file_name='qubes-new-qube-light.css',
                    dark_file_name='qubes-new-qube-dark.css')
 
+        self.progress_bar_dialog.show_all()
         self.progress_bar_dialog.update_progress(0.1)
 
         self.template_handler = TemplateHandler(self.builder, self.qapp)

--- a/qubes_config/widgets/gtk_widgets.py
+++ b/qubes_config/widgets/gtk_widgets.py
@@ -649,7 +649,6 @@ class ProgressBarDialog(Gtk.Window):
 
         self.box.pack_start(self.progress_bar, False, False, 10)
 
-        self.show_all()
         self.update_progress(0)
 
         self.connect('delete-event', self._quit)


### PR DESCRIPTION
If the progress bar is shown before loading the application CSS theme, it looks like a graphical glitch for around 744ms on my HP Elitebook 820 system. Until the next call to `update_progress` and `Gtk.main_iteration_do` loop (picture below).

But if the progress bar is shown and updated right after loading the CSS theme, it is much prettier.

![progress_bar2](https://github.com/user-attachments/assets/bd240f5e-39a5-453e-b5d4-24a6d3374622)

![progress_bar1](https://github.com/user-attachments/assets/e39539c7-37e2-4f22-af99-eacfc2416ce9)
