### PR TITLE
updater: make UpdateListIter a proper iterator

### DIFF
--- a/qui/updater/utils.py
+++ b/qui/updater/utils.py
@@ -274,6 +274,9 @@ class UpdateListIter:
         self.list_store_wrapped = list_store_wrapped
         self._id = -1
 
+    def __iter__(self) -> "UpdateListIter":
+        return self
+
     def __next__(self) -> RowWrapper:
         self._id += 1
         if 0 <= self._id < len(self.list_store_wrapped):


### PR DESCRIPTION
Python iterators are required to implement an `__iter__()` that returns
self [1].  CPython doesn't check this consistently, but the requirement
is still there, so the existing code is buggy.  Python 3.13 started
checking this in list comprehensions, resulting in exceptions being
thrown.  Fix the bug by having `__iter__()` return self, as required by
the iterator protocol.

This worked on Python 3.13 and below, but broke in 3.13.1 [2].

[1]: https://docs.python.org/3/glossary.html#term-iterator
[2]: https://github.com/python/cpython/issues/128211