### PR TITLE
Don't change combobox on mouse scroll

### DIFF
--- a/qubes_config/global_config/global_config.py
+++ b/qubes_config/global_config/global_config.py
@@ -438,6 +438,12 @@ class GlobalConfig(Gtk.Application):
              self.builder.get_object('thisdevice_scrolled_window'),
              ])
 
+        # workaround the uncomfortable behavior with comboboxes: combobox
+        # should not change item ID on random scrolling around
+        for obj in self.builder.get_objects():
+            if isinstance(obj, (Gtk.ComboBox, Gtk.ComboBoxText)):
+                obj.connect("scroll-event", lambda *args: True)
+
         self.progress_bar_dialog.update_progress(1)
         self.progress_bar_dialog.hide()
         self.progress_bar_dialog.destroy()


### PR DESCRIPTION
This causes problems and is inconvenient, easy to change something by accident

fixes QubesOS/qubes-issues#9675