### PR TITLE
Center Global Config after window resize

### DIFF
--- a/qubes_config/global_config/global_config.py
+++ b/qubes_config/global_config/global_config.py
@@ -57,7 +57,7 @@ from .thisdevice_handler import ThisDeviceHandler
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, GLib, GObject, Gio
+from gi.repository import Gtk, GLib, GObject, Gio, Gdk
 
 logger = logging.getLogger("qubes-global-config")
 
@@ -314,6 +314,10 @@ class GlobalConfig(Gtk.Application):
         else:
             height = self.main_window.get_allocated_height()
         self.main_window.resize(width, height)
+        self.main_window.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
+        self.main_window.set_gravity(Gdk.Gravity.CENTER)
+        self.main_window.move(0, 0)
+        self.main_window.set_position(Gtk.WindowPosition.CENTER)
 
         # open at specified location
         if self.open_at:


### PR DESCRIPTION
Assure Global Config window will remain on the center of the screen after window is resized.