### PR TITLE
Missing dependencies in RPM spec

### DIFF
--- a/rpm_spec/qubes-desktop-linux-manager.spec.in
+++ b/rpm_spec/qubes-desktop-linux-manager.spec.in
@@ -61,6 +61,8 @@ Requires:  qubes-artwork >= 4.1.5
 Requires:  xhost
 Requires:  gtksourceview4
 Requires:  gnome-icon-theme
+Requires:  xfce4-settings
+Requires:  python%{python3_pkgversion}-gobject
 
 Provides:   qui = %{version}-%{release}
 Obsoletes:  qui < 4.0.0


### PR DESCRIPTION
Add dependencies which were easily removed and could break icons and some UX features. Resolves QubesOS/qubes-issues/issues/9359