### PR TITLE
More flexible behavior for async behavior

### DIFF
--- a/qui/updater/summary_page.py
+++ b/qui/updater/summary_page.py
@@ -318,8 +318,12 @@ class SummaryPage:
                 self.err += vm.name + " cannot shutdown: " + str(err) + "\n"
                 self.log.error("Cannot shutdown %s because %s", vm.name, str(err))
                 self.status = RestartStatus.ERROR_TMPL_DOWN
-
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # changes between GLib versions and python versions mean that the above
+            # can fail on some dom0/gui domain configurations
+            loop = asyncio.new_event_loop()
         loop.run_until_complete(wait_for_domain_shutdown(wait_for))
 
         return wait_for


### PR DESCRIPTION
As behavior of asyncio.get_event_loop changes between python 3.10 and 3.12, and GLib asyncio integration is still experimental, some combinations of python/glib
versions could fail at running a new event loop.
This workaround should handle all combinations.