### PR TITLE
Add preload memory threshold spin button

### DIFF
--- a/qubes_config/global_config.glade
+++ b/qubes_config/global_config.glade
@@ -976,7 +976,7 @@
                     <property name="can-focus">False</property>
                     <property name="vscroll-policy">natural</property>
                     <child>
-                      <!-- n-columns=2 n-rows=26 -->
+                      <!-- n-columns=2 n-rows=27 -->
                       <object class="GtkGrid" id="basics_contents">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -1069,7 +1069,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">10</property>
+                            <property name="top-attach">11</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1085,7 +1085,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">13</property>
+                            <property name="top-attach">14</property>
                           </packing>
                         </child>
                         <child>
@@ -1101,7 +1101,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">13</property>
+                            <property name="top-attach">14</property>
                           </packing>
                         </child>
                         <child>
@@ -1114,7 +1114,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">14</property>
+                            <property name="top-attach">15</property>
                           </packing>
                         </child>
                         <child>
@@ -1127,7 +1127,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">15</property>
+                            <property name="top-attach">16</property>
                           </packing>
                         </child>
                         <child>
@@ -1238,7 +1238,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">17</property>
+                            <property name="top-attach">18</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1255,7 +1255,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">18</property>
+                            <property name="top-attach">19</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1271,7 +1271,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">22</property>
+                            <property name="top-attach">23</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1283,7 +1283,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">24</property>
+                            <property name="top-attach">25</property>
                           </packing>
                         </child>
                         <child>
@@ -1295,7 +1295,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">25</property>
+                            <property name="top-attach">26</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1312,7 +1312,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">23</property>
+                            <property name="top-attach">24</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1462,7 +1462,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">11</property>
+                            <property name="top-attach">12</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1509,7 +1509,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">12</property>
+                            <property name="top-attach">13</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -1554,7 +1554,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">14</property>
+                            <property name="top-attach">15</property>
                           </packing>
                         </child>
                         <child>
@@ -1578,7 +1578,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">9</property>
+                            <property name="top-attach">10</property>
                           </packing>
                         </child>
                         <child>
@@ -1590,7 +1590,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">16</property>
+                            <property name="top-attach">17</property>
                           </packing>
                         </child>
                         <child>
@@ -1602,7 +1602,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">21</property>
+                            <property name="top-attach">22</property>
                           </packing>
                         </child>
                         <child>
@@ -1633,7 +1633,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">15</property>
+                            <property name="top-attach">16</property>
                           </packing>
                         </child>
                         <child>
@@ -1648,7 +1648,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">24</property>
+                            <property name="top-attach">25</property>
                           </packing>
                         </child>
                         <child>
@@ -1663,7 +1663,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">19</property>
+                            <property name="top-attach">20</property>
                           </packing>
                         </child>
                         <child>
@@ -1678,7 +1678,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">20</property>
+                            <property name="top-attach">21</property>
                           </packing>
                         </child>
                         <child>
@@ -1718,7 +1718,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">19</property>
+                            <property name="top-attach">20</property>
                           </packing>
                         </child>
                         <child>
@@ -1758,7 +1758,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
-                            <property name="top-attach">20</property>
+                            <property name="top-attach">21</property>
                           </packing>
                         </child>
                         <child>
@@ -1858,7 +1858,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
@@ -1876,13 +1876,83 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
                             <property name="top-attach">8</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkSpinButton" id="basics_preload_dispvm_threshold">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="valign">center</property>
+                                <property name="max-width-chars">6</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-end">5</property>
+                                <property name="hexpand">True</property>
+                                <property name="label" translatable="yes">MiB</property>
+                                <style>
+                                  <class name="main_text"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">9</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Memory threshold that is deducted from the calculation of system's available memory. Useful to prevent memory exhaustion.</property>
+                                <property name="wrap">True</property>
+                                <property name="xalign">0</property>
+                                <style>
+                                  <class name="explanation"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">9</property>
                           </packing>
                         </child>
                         <child>

--- a/qubes_config/global_config/basics_handler.py
+++ b/qubes_config/global_config/basics_handler.py
@@ -223,22 +223,37 @@ class PreloadDispvmHandler(AbstractTraitHolder):
         self.preload_dispvm_spin: Gtk.SpinButton = gtk_builder.get_object(
             "basics_preload_dispvm"
         )
+        self.preload_dispvm_threshold_spin: Gtk.SpinButton = gtk_builder.get_object(
+            "basics_preload_dispvm_threshold"
+        )
         self.preload_dispvm_check: Gtk.CheckButton = gtk_builder.get_object(
             "basics_preload_dispvm_check"
         )
 
         self.defdispvm_model.connect_change_callback(self.on_defdispvm_changed)
         self.preload_dispvm_check.connect("toggled", self.on_check_changed)
+
+        self.default_max = 1
         self.preload_dispvm_spin.props.numeric = True
         self.preload_dispvm_spin_adjustment = Gtk.Adjustment()
         self.preload_dispvm_spin_adjustment.configure(0, 0, 9999, 1, 5, 0)
         self.preload_dispvm_spin.configure(self.preload_dispvm_spin_adjustment, 0.1, 0)
+
+        self.preload_dispvm_threshold_spin.props.numeric = True
+        self.preload_dispvm_threshold_spin_adjustment = Gtk.Adjustment()
+        self.preload_dispvm_threshold_spin_adjustment.configure(
+            0, 0, 999999, 100, 1000, 0
+        )
+        self.preload_dispvm_threshold_spin.configure(
+            self.preload_dispvm_threshold_spin_adjustment, 0.1, 0
+        )
 
         self.on_defdispvm_changed()
         self.on_check_changed()
         self.initial_preload_dispvm_spin_sensitive = (
             self.preload_dispvm_spin.is_sensitive()
         )
+        self.preload_dispvm_threshold_spin.set_value(self.get_current_threshold_value())
 
     def on_defdispvm_changed(self):
         defdispvm = self.defdispvm_model.get_selected()
@@ -254,7 +269,7 @@ class PreloadDispvmHandler(AbstractTraitHolder):
         preloadcheck = self.preload_dispvm_check.get_active()
         if defdispvm and preloadcheck:
             if self.get_feat_value() is None:
-                value = 1
+                value = self.default_max
             else:
                 value = self.get_current_value()
             self.preload_dispvm_spin.set_value(value)
@@ -274,11 +289,19 @@ class PreloadDispvmHandler(AbstractTraitHolder):
         """Get current system value as is"""
         return get_feature(self.qapp.domains["dom0"], "preload-dispvm-max")
 
+    def get_feat_threshold_value(self):
+        """Get current system threshold value as is"""
+        return get_feature(self.qapp.domains["dom0"], "preload-dispvm-threshold")
+
     def get_current_value(self):
         """Get current system value of the handled feature"""
         return int(self.get_feat_value() or 0)
 
-    def is_changed(self) -> bool:
+    def get_current_threshold_value(self):
+        """Get current system value of the handled feature"""
+        return int(self.get_feat_threshold_value() or 0)
+
+    def is_max_changed(self) -> bool:
         """Has the user selected something different from the initial value?"""
         if (
             self.initial_preload_dispvm_spin_sensitive
@@ -286,6 +309,19 @@ class PreloadDispvmHandler(AbstractTraitHolder):
         ):
             return True
         if self.preload_dispvm_spin.get_value_as_int() != self.get_current_value():
+            return True
+        return False
+
+    def is_threshold_changed(self) -> bool:
+        """Has the user selected something different from the initial value?"""
+        return (
+            self.preload_dispvm_threshold_spin.get_value_as_int()
+            != self.get_current_threshold_value()
+        )
+
+    def is_changed(self) -> bool:
+        """Has the user selected something different from the initial value?"""
+        if self.is_max_changed() or self.is_threshold_changed():
             return True
         return False
 
@@ -300,25 +336,38 @@ class PreloadDispvmHandler(AbstractTraitHolder):
         """Save changes: update system value and mark it as new initial value"""
         if not self.is_changed():
             return
-        if self.preload_dispvm_spin.is_sensitive():
-            value = str(self.preload_dispvm_spin.get_value_as_int())
-        else:
-            value = None
-        apply_feature_change(
-            self.qapp.domains["dom0"],
-            "preload-dispvm-max",
-            value,
-        )
-        if value is None:
-            self.initial_preload_dispvm_spin_sensitive = False
-        else:
-            self.initial_preload_dispvm_spin_sensitive = True
+
+        if self.is_threshold_changed():
+            threshold_value = str(self.preload_dispvm_threshold_spin.get_value_as_int())
+            apply_feature_change(
+                self.qapp.domains["dom0"],
+                "preload-dispvm-threshold",
+                threshold_value,
+            )
+
+        # Every other feature must be set before "max" (prior to preload routine).
+        if self.is_max_changed():
+            if self.preload_dispvm_spin.is_sensitive():
+                value = str(self.preload_dispvm_spin.get_value_as_int())
+            else:
+                value = None
+            apply_feature_change(
+                self.qapp.domains["dom0"],
+                "preload-dispvm-max",
+                value,
+            )
+            if value is None:
+                self.initial_preload_dispvm_spin_sensitive = False
+            else:
+                self.initial_preload_dispvm_spin_sensitive = True
 
     def reset(self):
         """Reset selection to the initial value."""
-        if not self.preload_dispvm_spin.is_sensitive():
-            return
-        self.preload_dispvm_spin.set_value(self.get_current_value())
+        if self.preload_dispvm_spin.is_sensitive():
+            self.preload_dispvm_spin.set_value(self.get_current_value())
+        if self.preload_dispvm_threshold_spin.is_sensitive():
+            self.preload_dispvm_threshold_spin.set_value(self.get_current_threshold_value())
+
 
     def update_current_value(self):
         """This should never be called."""

--- a/qubes_config/tests/test_basics_handler.py
+++ b/qubes_config/tests/test_basics_handler.py
@@ -23,7 +23,8 @@
 # pylint: disable=protected-access
 
 import os
-from unittest.mock import Mock, patch
+import unittest.mock as mock
+from unittest.mock import Mock, patch, call
 from ..global_config.basics_handler import (
     KernelVersion,
     PropertyHandler,
@@ -344,6 +345,8 @@ def test_kernels(test_qapp):
 def test_preload_handler(
     mock_apply, mock_get, real_builder, test_qapp
 ):  # pylint: disable=unused-argument
+    default_max = 1
+    default_threshold = 0
     description = "Number of preloaded disposables from default dispvm"
     mock_get.return_value = None
     basics_handler = BasicSettingsHandler(real_builder, test_qapp)
@@ -356,6 +359,9 @@ def test_preload_handler(
     preload_dispvm_spin: Gtk.SpinButton = real_builder.get_object(
         "basics_preload_dispvm"
     )
+    preload_dispvm_threshold_spin: Gtk.SpinButton = real_builder.get_object(
+        "basics_preload_dispvm_threshold"
+    )
     preload_dispvm_spin_check: Gtk.CheckButton = real_builder.get_object(
         "basics_preload_dispvm_check"
     )
@@ -364,11 +370,15 @@ def test_preload_handler(
 
     # Start available but unchecked.
     assert preload_dispvm_spin_check.is_sensitive()
+    assert preload_dispvm_spin.get_value_as_int() == 0
     assert not preload_dispvm_spin.is_sensitive()
+    assert preload_dispvm_threshold_spin.is_sensitive()
+    assert preload_dispvm_threshold_spin.get_value_as_int() == default_threshold
 
     # Check to allow spin.
     preload_dispvm_spin_check.set_active(True)
     assert preload_dispvm_spin.is_sensitive()
+    assert preload_dispvm_spin.get_value_as_int() == default_max
 
     # Assert that with no default_dispvm, even if changing preload spin button,
     # doesn't save the preload feature.
@@ -391,7 +401,7 @@ def test_preload_handler(
     # Assert that reset ignores insensitive.
     initial_preload_dispvm = preload_dispvm_spin.get_value_as_int()
     assert not preload_dispvm_spin.is_sensitive()
-    mock_get_count = mock_get.call_count
+    mock_get_count = mock_get.call_count + 1
     basics_handler.reset()
     assert mock_get_count == mock_get.call_count
 
@@ -416,13 +426,15 @@ def test_preload_handler(
         assert call not in test_qapp.actual_calls
     basics_handler.save()
     mock_apply.assert_called_once_with(
-        test_qapp.domains["dom0"], "preload-dispvm-max", str(new_preload_value)
+        test_qapp.domains["dom0"],
+        "preload-dispvm-max",
+        str(new_preload_value),
     )
     for call in expected_calls:
         assert call in test_qapp.actual_calls
     test_qapp.actual_calls = []
 
-    # Assert that saving '0' set the value '0' instead of feature deletion.
+    # Assert that saving '0' sets the value '0' instead of feature deletion.
     mock_get.return_value = new_preload_value
     preload_dispvm_spin.set_value(0)
     basics_handler.save()
@@ -431,33 +443,50 @@ def test_preload_handler(
         "preload-dispvm-max",
         str(0),
     )
+    test_qapp.actual_calls = []
 
     # Assert that deselecting the check box deletes the feature.
     mock_get.return_value = 0
+    threshold_value = preload_dispvm_threshold_spin.get_value_as_int()
     preload_dispvm_spin.set_value(1)
     preload_dispvm_spin_check.set_active(False)
+    # Assert that threshold is not impacted.
+    assert preload_dispvm_threshold_spin.is_sensitive()
+    assert preload_dispvm_threshold_spin.get_value_as_int() == threshold_value
+    mock_apply_count = mock_apply.call_count
     basics_handler.save()
-    assert mock_apply.call_args[0] == (
+    assert mock_apply.call_count == mock_apply_count + 1
+    mock_apply.call_args[-1] == (
         test_qapp.domains["dom0"],
         "preload-dispvm-max",
         None,
     )
     assert not preload_dispvm_spin.is_sensitive()
 
-    # Assert that reset sets the current value.
+    # Assert that reset sets the current value of 'max' and 'threshold'
     preload_dispvm_spin_check.set_active(True)
     assert preload_dispvm_spin.is_sensitive()
     mock_get_count = mock_get.call_count
-    mock_get.return_value = 1
+
+    def feature_side_effect(_vm, feature, default=None):
+        if feature == "preload-dispvm-max":
+            return default_max
+        elif feature == "preload-dispvm-threshold":
+            return default_threshold
+        return default
+
+    mock_get.side_effect = feature_side_effect
     basics_handler.reset()
-    assert mock_get.call_count == mock_get_count + 1
-    assert preload_dispvm_spin.get_value_as_int() == 1
+    assert mock_get.call_count == mock_get_count + 2
+    assert preload_dispvm_spin.get_value_as_int() == default_max
+    assert preload_dispvm_threshold_spin.get_value_as_int() == default_threshold
+    mock_get.side_effect = None
 
     # Assert that value is 1 when feature is None, get current value otherwise.
     mock_get.return_value = None
     preload_dispvm_spin_check.set_active(False)
     preload_dispvm_spin_check.set_active(True)
-    assert preload_dispvm_spin.get_value_as_int() == 1
+    assert preload_dispvm_spin.get_value_as_int() == default_max
 
     mock_get.return_value = 0
     preload_dispvm_spin_check.set_active(False)
@@ -472,7 +501,18 @@ def test_preload_handler(
     mock_get.return_value = 1
     preload_dispvm_spin_check.set_active(False)
     preload_dispvm_spin_check.set_active(True)
-    assert preload_dispvm_spin.get_value_as_int() == 1
+    assert preload_dispvm_spin.get_value_as_int() == default_max
+
+    new_threshold = preload_dispvm_threshold_spin.get_value_as_int() + 1
+    preload_dispvm_threshold_spin.set_value(new_threshold)
+    mock_apply_count = mock_apply.call_count
+    basics_handler.save()
+    assert mock_apply.call_count == mock_apply_count + 1
+    mock_apply.call_args[-1] == (
+        test_qapp.domains["dom0"],
+        "preload-dispvm-theshold",
+        str(new_threshold),
+    )
 
 
 def test_basics_handler(real_builder, test_qapp):


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/1512
For: https://github.com/QubesOS/qubes-issues/issues/10027

---

Bad resolution because of VNC:

<img width="637" height="162" alt="hi" src="https://github.com/user-attachments/assets/03eb0948-3689-4582-bd4b-dcabe8fcba96" />

It starts the value as `0` but doesn't save it if the feature is not set yet. Yes, there is no way to remove the feature, but value `0` is equal to a deleted feature in this case, as it does not the behavior of `preload-dispvm-max` being set or not.