### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/qui/clipboard.py
+++ b/qui/clipboard.py
@@ -480,7 +480,8 @@ class NotificationApp(Gtk.Application):
 
 
 def main():
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     wm = pyinotify.WatchManager()
 
     qubes_app = qubesadmin.Qubes()

--- a/qui/devices/device_widget.py
+++ b/qui/devices/device_widget.py
@@ -667,7 +667,8 @@ def main():
     # dispatcher = qubesadmin.tests.mock_app.MockDispatcher(qapp)
     app = DevicesTray("org.qubes.qui.tray.Devices", qapp, dispatcher)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     return_code = qui.utils.run_asyncio_and_show_errors(
         loop,
         [asyncio.ensure_future(dispatcher.listen_for_events())],

--- a/qui/tools/qubes_device_agent.py
+++ b/qui/tools/qubes_device_agent.py
@@ -253,7 +253,8 @@ def main():
 
     agent = DeviceAgent(args.socket_path)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.run_until_complete(agent.run())
 
 

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -1201,7 +1201,8 @@ def main():
     app = DomainTray("org.qubes.qui.tray.Domains", qapp, dispatcher, stats_dispatcher)
     app.run()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     tasks = [
         asyncio.ensure_future(dispatcher.listen_for_events()),
         asyncio.ensure_future(stats_dispatcher.listen_for_events()),

--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -263,7 +263,8 @@ def main():
     app = UpdatesTray("org.qubes.qui.tray.Updates", qapp, dispatcher)
     app.run()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     return qui.utils.run_asyncio_and_show_errors(
         loop,


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

Resolves: QubesOS/qubes-issues#10188