### PR TITLE
Add flag to allow independent instances of policy editor

### DIFF
--- a/qubes_config/policy_editor/policy_editor.py
+++ b/qubes_config/policy_editor/policy_editor.py
@@ -43,7 +43,6 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("GtkSource", "4")
 from gi.repository import Gtk, GtkSource, Gio, Gdk
 
-
 HEADER_NORMAL = (
     " service_name\targument\tsource_qube\ttarget_qube\taction [parameter=value]    "
 )
@@ -156,7 +155,10 @@ class PolicyEditor(Gtk.Application):
     """
 
     def __init__(self, filename: str, policy_client: PolicyClient):
-        super().__init__(application_id="org.qubesos.policyeditor")
+        super().__init__(
+            application_id="org.qubesos.policyeditor",
+            flags=Gio.ApplicationFlags.NON_UNIQUE,
+        )
         self.token: Optional[str] = None
         self.policy_client = PolicyClientWrapper(policy_client)
         self.filename = filename


### PR DESCRIPTION
Fixes [#9913](https://github.com/QubesOS/qubes-issues/issues/9913) by allowing for multiple independent instances of the policy editor.

By default, when a GTK application is already running and the application is launched again, the arguments are passed to the already running instance.

Methods in policy editor, such as `_quit()`, act on the application level, not on a window or panel, leading to unexpected behavior when opening multiple windows of the editor, like closing all windows of the application when trying to only close one.

Since we do not need to share any state between multiple editor instances we can set the `NON_UNIQUE` [1] flag to put each new editor instance into its own process. 

We could also keep everything in the same process and update the implementation to handle everything correctly, but unless we want to implement tabs or something similar, I don't know whether that has any advantages.

[1] https://docs.gtk.org//gio/flags.ApplicationFlags.html#non_unique


Writing tests for this seemed more trouble than it's worth, so I only tested it against the existing suite and manually on dom0. If you need tests I'll try to write some after I figure out how to set up the rest of the dev environment.

**Before**:

<img width="923" height="265" alt="policyed-unique" src="https://github.com/user-attachments/assets/5e2b278a-1df1-428b-8e69-7cc29e4f1fed" />

All windows get assigned to the same instance / process.
Opening two windows and then closing one of them quits the whole process.
_Undo_ in one window reverts the latest change done in any window.

**After**:

<img width="896" height="254" alt="policyed-non-unique" src="https://github.com/user-attachments/assets/79a209ed-36ae-44d3-9b58-6f6d76ee98da" />

Each instance / process is independent.