### PR TITLE
Allow passing pytest arguments

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python3 -m coverage run -m pytest -vv qubes_config/tests qui
+python3 -m coverage run -m pytest -vv qubes_config/tests qui "$@"


### PR DESCRIPTION
Example to run subset of tests:

        xvfb-run ./run-tests.sh -k test_subset_handler