### PR TITLE
Schedule synchronous function to separate thread

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Description: Qubes UI Applications
 Package: python3-qui
 Architecture: any
 Depends:
- python3-qubesadmin (>= 4.3.19),
+ python3-qubesadmin (>= 4.3.33),
  python3-gi,
  ${python3:Depends},
  ${misc:Depends}

--- a/qui/devices/actionable_widgets.py
+++ b/qui/devices/actionable_widgets.py
@@ -27,6 +27,7 @@ Use generate_wrapper_widget to get a wrapped widget.
 import asyncio
 import functools
 import pathlib
+import time
 from typing import Iterable, Callable, Optional, List
 
 import qubesadmin
@@ -39,7 +40,6 @@ gi.require_version("Gtk", "3.0")  # isort:skip
 from gi.repository import Gtk, GdkPixbuf, GLib  # isort:skip
 
 from . import backend
-import time
 
 
 def load_icon(icon_name: str, backup_name: str, size: int = 24):
@@ -248,7 +248,7 @@ class AttachWidget(ActionableWidget, VMWithIcon):
             self.actionable = False
 
     async def widget_action(self, *_args):
-        self.device.attach_to_vm(self.vm)
+        await asyncio.to_thread(self.device.attach_to_vm, self.vm)
 
 
 class DetachWidget(ActionableWidget, SimpleActionWidget):
@@ -260,7 +260,7 @@ class DetachWidget(ActionableWidget, SimpleActionWidget):
         self.device = device
 
     async def widget_action(self, *_args):
-        self.device.detach_from_vm(self.vm, False)
+        await asyncio.to_thread(self.device.detach_from_vm, self.vm, False)
 
 
 class DetachWithWidget(ActionableWidget, SimpleActionWidget):
@@ -279,7 +279,7 @@ class DetachWithWidget(ActionableWidget, SimpleActionWidget):
         self.device = device
 
     async def widget_action(self, *_args):
-        self.device.detach_from_vm(self.vm, True)
+        await asyncio.to_thread(self.device.detach_from_vm, self.vm, True)
 
 
 class DetachAndShutdownWidget(ActionableWidget, SimpleActionWidget):
@@ -293,8 +293,8 @@ class DetachAndShutdownWidget(ActionableWidget, SimpleActionWidget):
         self.device = device
 
     async def widget_action(self, *_args):
-        self.device.detach_from_vm(self.vm, True)
-        self.vm.vm_object.shutdown()
+        await asyncio.to_thread(self.device.detach_from_vm, self.vm, True)
+        await asyncio.to_thread(self.vm.vm_object.shutdown)
 
 
 class DetachAndAttachWidget(ActionableWidget, VMWithIcon):
@@ -307,8 +307,8 @@ class DetachAndAttachWidget(ActionableWidget, VMWithIcon):
 
     async def widget_action(self, *_args):
         for vm in self.device.attachments:
-            self.device.detach_from_vm(vm, True)
-        self.device.attach_to_vm(self.vm)
+            await asyncio.to_thread(self.device.detach_from_vm, vm, True)
+        await asyncio.to_thread(self.device.attach_to_vm, self.vm)
 
 
 class AttachDisposableWidget(ActionableWidget, VMWithIcon):
@@ -321,9 +321,9 @@ class AttachDisposableWidget(ActionableWidget, VMWithIcon):
 
     async def widget_action(self, *_args):
         new_dispvm = qubesadmin.vm.DispVM.from_appvm(self.vm.vm_object.app, self.vm)
-        new_dispvm.start()
+        await asyncio.to_thread(new_dispvm.start)
 
-        self.device.attach_to_vm(backend.VM(new_dispvm))
+        await asyncio.to_thread(self.device.attach_to_vm, backend.VM(new_dispvm))
 
 
 class DetachAndAttachDisposableWidget(ActionableWidget, VMWithIcon):
@@ -335,11 +335,11 @@ class DetachAndAttachDisposableWidget(ActionableWidget, VMWithIcon):
         self.device = device
 
     async def widget_action(self, *_args):
-        self.device.detach_from_vm(self.vm)
+        await asyncio.to_thread(self.device.detach_from_vm, self.vm)
         new_dispvm = qubesadmin.vm.DispVM.from_appvm(self.vm.vm_object.app, self.vm)
-        new_dispvm.start()
+        await asyncio.to_thread(new_dispvm.start)
 
-        self.device.attach_to_vm(backend.VM(new_dispvm))
+        await asyncio.to_thread(self.device.attach_to_vm, backend.VM(new_dispvm))
 
 
 class ToggleFeatureItem(ActionableWidget, SimpleActionWidget):
@@ -380,7 +380,7 @@ class StartUSBVM(ActionableWidget, SimpleActionWidget):
         self.usbvm = usbvm
 
     async def widget_action(self, *_args):
-        self.usbvm.vm_object.start()
+        await asyncio.to_thread(self.usbvm.vm_object.start)
 
 
 #### Configuration-related actions

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -203,19 +203,15 @@ class ShutdownItem(VMActionMenuItem):
         icon_name="shutdown",
     ):
         if force:
-            super().__init__(
-                vm,
-                label=force_label or _("Force shutdown"),
-                icon_cache=icon_cache,
-                icon_name=icon_name,
-            )
+            init_label = force_label or _("Force shutdown")
         else:
-            super().__init__(
-                vm,
-                label=label or _("Shutdown"),
-                icon_cache=icon_cache,
-                icon_name=icon_name,
-            )
+            init_label = label or _("Shutdown")
+        super().__init__(
+            vm,
+            label=init_label,
+            icon_cache=icon_cache,
+            icon_name=icon_name,
+        )
         self.force = force
         self.follow_shift = follow_shift
 

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -157,7 +157,7 @@ class PauseItem(VMActionMenuItem):
 
     async def perform_action(self):
         try:
-            self.vm.pause()
+            await asyncio.to_thread(self.vm.pause)
         except exc.QubesException as ex:
             show_error(
                 _("Error pausing qube"),
@@ -178,7 +178,7 @@ class UnpauseItem(VMActionMenuItem):
 
     async def perform_action(self):
         try:
-            self.vm.unpause()
+            await asyncio.to_thread(self.vm.unpause)
         except exc.QubesException as ex:
             show_error(
                 _("Error unpausing qube"),
@@ -215,7 +215,7 @@ class ShutdownItem(VMActionMenuItem):
 
     async def perform_action(self):
         try:
-            self.vm.shutdown(force=self.force)
+            await asyncio.to_thread(self.vm.shutdown, force=self.force, wait=True)
         except exc.QubesException as ex:
             if self.force:
                 show_error(
@@ -271,19 +271,22 @@ class ShutdownItem(VMActionMenuItem):
             GLib.idle_add(dialog.show)
 
     def react_to_question(self, widget, response, action):
+        asyncio.create_task(self.react_to_question_async(widget, response, action))
+
+    async def react_to_question_async(self, widget, response, action):
         if response not in (Gtk.ResponseType.OK, Gtk.ResponseType.YES):
             widget.destroy()
             return
         try:
             if action == "force":
-                self.vm.shutdown(force=True)
+                await asyncio.to_thread(self.vm.shutdown, force=True, wait=True)
             elif action == "timeout":
                 if response == Gtk.ResponseType.YES:
-                    self.vm.kill()
+                    await asyncio.to_thread(self.vm.kill)
                 elif response == Gtk.ResponseType.OK:
-                    self.vm.shutdown(force=False)
+                    await asyncio.to_thread(self.vm.shutdown, force=False, wait=True)
             elif action == "kill" and response == Gtk.ResponseType.OK:
-                self.vm.kill()
+                await asyncio.to_thread(self.vm.kill)
         except exc.QubesException as ex:
             show_error(
                 _("Error shutting down qube"),
@@ -320,7 +323,7 @@ class RestartItem(VMActionMenuItem):
 
     async def perform_action(self, *_args, **_kwargs):
         try:
-            self.vm.shutdown(force=self.force)
+            await asyncio.to_thread(self.vm.shutdown, force=self.force, wait=True)
         except exc.QubesException as ex:
             if self.force:
                 # we already tried forcing it, let's just give up
@@ -351,12 +354,7 @@ class RestartItem(VMActionMenuItem):
                 if self.give_up:
                     return
                 await asyncio.sleep(1)
-            proc = await asyncio.create_subprocess_exec(
-                "qvm-start", self.vm.name, stderr=asyncio.subprocess.PIPE
-            )
-            _stdout, stderr = await proc.communicate()
-            if proc.returncode != 0:
-                raise exc.QubesException(stderr)
+            await asyncio.to_thread(self.vm.start)
         except exc.QubesException as ex:
             show_error(
                 _("Error restarting qube"),
@@ -367,9 +365,12 @@ class RestartItem(VMActionMenuItem):
             )
 
     def react_to_question(self, widget, response):
+        asyncio.create_task(self.react_to_question_async(widget, response))
+
+    async def react_to_question_async(self, widget, response):
         if response == Gtk.ResponseType.OK:
             try:
-                self.vm.shutdown(force=True)
+                await asyncio.to_thread(self.vm.shutdown, force=True, wait=True)
             except exc.QubesException as ex:
                 show_error(
                     _("Error shutting down qube"),
@@ -392,13 +393,13 @@ class KillItem(VMActionMenuItem):
 
     async def perform_action(self, *_args, **_kwargs):
         try:
-            self.vm.kill()
+            await asyncio.to_thread(self.vm.kill)
         except exc.QubesException as ex:
             show_error(
                 _("Error shutting down qube"),
                 _(
-                    "The following error occurred while attempting to shut"
-                    "down qube {0}:\n{1}"
+                    "The following error occurred while attempting to kill"
+                    "qube {0}:\n{1}"
                 ).format(self.vm.name, str(ex)),
             )
 
@@ -459,7 +460,11 @@ class RunTerminalItem(VMActionMenuItem):
         if self.as_root:
             service_args["user"] = "root"
         try:
-            self.vm.run_service("qubes.StartApp+qubes-run-terminal", **service_args)
+            await asyncio.to_thread(
+                self.vm.run_service_for_stdio,
+                "qubes.StartApp+qubes-run-terminal",
+                **service_args,
+            )
         except exc.QubesException as ex:
             show_error(
                 _("Error starting terminal"),
@@ -508,7 +513,9 @@ class OpenFileManagerItem(VMActionMenuItem):
 
     async def perform_action(self):
         try:
-            self.vm.run_service("qubes.StartApp+qubes-open-file-manager")
+            await asyncio.to_thread(
+                self.vm.run_service_for_stdio, "qubes.StartApp+qubes-open-file-manager"
+            )
         except exc.QubesException as ex:
             show_error(
                 _("Error opening file manager"),

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -283,14 +283,11 @@ class ShutdownItem(VMActionMenuItem):
         asyncio.create_task(self.react_to_question_async(widget, response, action))
 
     async def react_to_question_async(self, widget, response, action):
-        if response not in (Gtk.ResponseType.OK, Gtk.ResponseType.YES):
-            widget.destroy()
-            return
+        widget.destroy()
         try:
             await self.shutdown_from_response(response, action)
         except exc.QubesException as ex:
             self.show_shutdown_dialog(ex)
-        widget.destroy()
 
     async def shutdown_from_response(self, response, action):
         if action == "force":
@@ -352,9 +349,9 @@ class RestartItem(ShutdownItem):
         asyncio.create_task(self.react_to_question_async(widget, response, action))
 
     async def react_to_question_async(self, widget, response, action):
+        widget.destroy()
         if response not in (Gtk.ResponseType.OK, Gtk.ResponseType.YES):
             self.give_up = True
-            widget.destroy()
             return
         try:
             await self.shutdown_from_response(response, action)
@@ -362,7 +359,6 @@ class RestartItem(ShutdownItem):
             self.show_shutdown_dialog(ex)
         else:
             await self.start()
-        widget.destroy()
 
 
 class KillItem(VMActionMenuItem):

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -326,11 +326,7 @@ class RestartItem(ShutdownItem):
         else:
             self.label.set_text(_("Restart"))
 
-    async def perform_action(self, *_args, **_kwargs):
-        try:
-            await asyncio.to_thread(self.vm.shutdown, force=self.force, wait=True)
-        except exc.QubesException as ex:
-            self.show_shutdown_dialog(ex)
+    async def start(self):
         if self.give_up:
             return
         try:
@@ -344,6 +340,14 @@ class RestartItem(ShutdownItem):
                 ).format(self.vm.name, str(ex)),
             )
 
+    async def perform_action(self, *_args, **_kwargs):
+        try:
+            await asyncio.to_thread(self.vm.shutdown, force=self.force, wait=True)
+        except exc.QubesException as ex:
+            self.show_shutdown_dialog(ex)
+        else:
+            await self.start()
+
     def react_to_question(self, widget, response, action):
         asyncio.create_task(self.react_to_question_async(widget, response, action))
 
@@ -356,7 +360,8 @@ class RestartItem(ShutdownItem):
             await self.shutdown_from_response(response, action)
         except exc.QubesException as ex:
             self.show_shutdown_dialog(ex)
-            self.give_up = True
+        else:
+            await self.start()
         widget.destroy()
 
 

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -272,7 +272,10 @@ class ShutdownItem(VMActionMenuItem):
         if action == "force":
             dialog.add_button(_("Force shutdown"), Gtk.ResponseType.OK)
         elif action == "timeout":
-            dialog.add_button(_("Retry shutdown"), Gtk.ResponseType.OK)
+            if self.force:
+                dialog.add_button(_("Retry force shutdown"), Gtk.ResponseType.OK)
+            else:
+                dialog.add_button(_("Retry shutdown"), Gtk.ResponseType.OK)
             dialog.add_button(_("Kill"), Gtk.ResponseType.YES)
         elif action == "kill":
             dialog.add_button(_("Kill"), Gtk.ResponseType.OK)
@@ -291,12 +294,13 @@ class ShutdownItem(VMActionMenuItem):
 
     async def shutdown_from_response(self, response, action):
         if action == "force":
+            self.set_force(True)
             await asyncio.to_thread(self.vm.shutdown, force=True, wait=True)
         elif action == "timeout":
             if response == Gtk.ResponseType.YES:
                 await asyncio.to_thread(self.vm.kill)
             elif response == Gtk.ResponseType.OK:
-                await asyncio.to_thread(self.vm.shutdown, force=False, wait=True)
+                await asyncio.to_thread(self.vm.shutdown, force=self.force, wait=True)
         elif action == "kill" and response == Gtk.ResponseType.OK:
             await asyncio.to_thread(self.vm.kill)
 

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -192,21 +192,36 @@ class UnpauseItem(VMActionMenuItem):
 class ShutdownItem(VMActionMenuItem):
     """Shutdown menu Item. When activated shutdowns the domain."""
 
-    def __init__(self, vm, icon_cache, force=False):
+    def __init__(
+        self,
+        vm,
+        icon_cache,
+        force=False,
+        follow_shift=True,
+        label=None,
+        force_label=None,
+        icon_name="shutdown",
+    ):
         if force:
             super().__init__(
                 vm,
-                label=_("Force shutdown"),
+                label=force_label or _("Force shutdown"),
                 icon_cache=icon_cache,
-                icon_name="shutdown",
+                icon_name=icon_name,
             )
         else:
             super().__init__(
-                vm, label=_("Shutdown"), icon_cache=icon_cache, icon_name="shutdown"
+                vm,
+                label=label or _("Shutdown"),
+                icon_cache=icon_cache,
+                icon_name=icon_name,
             )
         self.force = force
+        self.follow_shift = follow_shift
 
     def set_force(self, force):
+        if not self.follow_shift:
+            return
         self.force = force
         if self.force:
             self.label.set_text(_("Force shutdown"))
@@ -217,58 +232,52 @@ class ShutdownItem(VMActionMenuItem):
         try:
             await asyncio.to_thread(self.vm.shutdown, force=self.force, wait=True)
         except exc.QubesException as ex:
-            if self.force:
-                show_error(
-                    _("Error shutting down qube"),
-                    _(
-                        "The following error occurred while attempting to "
-                        "shut down qube {0}:\n{1}"
-                    ).format(self.vm.name, str(ex)),
-                )
-                return
-            if isinstance(ex, exc.QubesVMInUseError):
-                title = _("Qube {0} is in use").format(self.vm.name)
-                markup = _(
-                    "The qube <b>{0}</b> could not be shut down because it "
-                    "is in use by connected qubes.\n\n"
-                    "<b>Warning:</b> force shutdown may cause unexpected "
-                    "issues in connected qubes."
-                ).format(self.vm.name)
-                button_label = _("Force shutdown")
-                action = "force"
-            elif isinstance(ex, exc.QubesVMShutdownTimeoutError):
-                title = _("Qube {0} shutdown timed out").format(self.vm.name)
-                markup = _(
-                    "The qube <b>{0}</b> did not shut down within the "
-                    "expected time.\n\nYou can retry the shutdown or, "
-                    "if the problem persists, kill the qube."
-                ).format(self.vm.name)
-                button_label = None  # timeout uses custom buttons below
-                action = "timeout"
-            else:
-                title = _("Error shutting down qube {0}").format(self.vm.name)
-                markup = _(
-                    "The qube <b>{0}</b> could not be shut down. "
-                    "The following error occurred:\n"
-                    "<tt>{1}</tt>\n\n"
-                    "Would you like to kill the qube?"
-                ).format(self.vm.name, str(ex))
-                button_label = _("Kill")
-                action = "kill"
+            self.show_shutdown_dialog(ex)
 
-            dialog = Gtk.MessageDialog(
-                None, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.NONE
-            )
-            dialog.set_title(title)
-            dialog.set_markup(markup)
-            dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
-            if action == "timeout":
-                dialog.add_button(_("Retry shutdown"), Gtk.ResponseType.OK)
-                dialog.add_button(_("Kill"), Gtk.ResponseType.YES)
-            else:
-                dialog.add_button(button_label, Gtk.ResponseType.OK)
-            dialog.connect("response", self.react_to_question, action)
-            GLib.idle_add(dialog.show)
+    def shutdown_exception_body(self, ex):
+        if isinstance(ex, exc.QubesVMInUseError):
+            title = _("Qube {0} is in use").format(self.vm.name)
+            markup = _(
+                "The qube <b>{0}</b> could not be shut down because it "
+                "is in use by connected qubes.\n\n"
+                "<b>Warning:</b> force shutdown may cause unexpected "
+                "issues in connected qubes."
+            ).format(self.vm.name)
+            action = "force"
+        elif isinstance(ex, exc.QubesVMShutdownTimeoutError):
+            title = _("Qube {0} shutdown timed out").format(self.vm.name)
+            markup = _(
+                "The qube <b>{0}</b> did not shut down within the "
+                "expected time.\n\nYou can retry the shutdown or, "
+                "if the problem persists, kill the qube."
+            ).format(self.vm.name)
+            action = "timeout"
+        else:
+            title = _("Error shutting down qube {0}").format(self.vm.name)
+            markup = _(
+                "The qube <b>{0}</b> could not be shut down. "
+                "The following error occurred:\n"
+                "<tt>{1}</tt>\n\n"
+                "Would you like to kill the qube?"
+            ).format(self.vm.name, str(ex))
+            action = "kill"
+        return title, markup, action
+
+    def show_shutdown_dialog(self, ex):
+        title, markup, action = self.shutdown_exception_body(ex)
+        dialog = Gtk.MessageDialog(None, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.NONE)
+        dialog.set_title(title)
+        dialog.set_markup(markup)
+        dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
+        if action == "force":
+            dialog.add_button(_("Force shutdown"), Gtk.ResponseType.OK)
+        elif action == "timeout":
+            dialog.add_button(_("Retry shutdown"), Gtk.ResponseType.OK)
+            dialog.add_button(_("Kill"), Gtk.ResponseType.YES)
+        elif action == "kill":
+            dialog.add_button(_("Kill"), Gtk.ResponseType.OK)
+        dialog.connect("response", self.react_to_question, action)
+        GLib.idle_add(dialog.show)
 
     def react_to_question(self, widget, response, action):
         asyncio.create_task(self.react_to_question_async(widget, response, action))
@@ -278,40 +287,36 @@ class ShutdownItem(VMActionMenuItem):
             widget.destroy()
             return
         try:
-            if action == "force":
-                await asyncio.to_thread(self.vm.shutdown, force=True, wait=True)
-            elif action == "timeout":
-                if response == Gtk.ResponseType.YES:
-                    await asyncio.to_thread(self.vm.kill)
-                elif response == Gtk.ResponseType.OK:
-                    await asyncio.to_thread(self.vm.shutdown, force=False, wait=True)
-            elif action == "kill" and response == Gtk.ResponseType.OK:
-                await asyncio.to_thread(self.vm.kill)
+            await self.shutdown_from_response(response, action)
         except exc.QubesException as ex:
-            show_error(
-                _("Error shutting down qube"),
-                _(
-                    "The following error occurred while attempting to "
-                    "shut down qube {0}:\n{1}"
-                ).format(self.vm.name, str(ex)),
-            )
+            self.show_shutdown_dialog(ex)
         widget.destroy()
 
+    async def shutdown_from_response(self, response, action):
+        if action == "force":
+            await asyncio.to_thread(self.vm.shutdown, force=True, wait=True)
+        elif action == "timeout":
+            if response == Gtk.ResponseType.YES:
+                await asyncio.to_thread(self.vm.kill)
+            elif response == Gtk.ResponseType.OK:
+                await asyncio.to_thread(self.vm.shutdown, force=False, wait=True)
+        elif action == "kill" and response == Gtk.ResponseType.OK:
+            await asyncio.to_thread(self.vm.kill)
 
-class RestartItem(VMActionMenuItem):
+
+class RestartItem(ShutdownItem):
     """Restart menu Item. When activated shutdowns the domain and
     then starts it again."""
 
     def __init__(self, vm, icon_cache, force=False):
-        if force:
-            super().__init__(
-                vm, label=_("Force restart"), icon_cache=icon_cache, icon_name="restart"
-            )
-        else:
-            super().__init__(
-                vm, label=_("Restart"), icon_cache=icon_cache, icon_name="restart"
-            )
-        self.force = force
+        super().__init__(
+            vm,
+            icon_cache,
+            force=force,
+            label=_("Restart"),
+            force_label=_("Force restart"),
+            icon_name="restart",
+        )
         self.give_up = False
 
     def set_force(self, force):
@@ -325,62 +330,32 @@ class RestartItem(VMActionMenuItem):
         try:
             await asyncio.to_thread(self.vm.shutdown, force=self.force, wait=True)
         except exc.QubesException as ex:
-            if self.force:
-                # we already tried forcing it, let's just give up
-                show_error(
-                    _("Error restarting qube"),
-                    _(
-                        "The following error occurred while attempting to restart"
-                        "qube {0}:\n{1}"
-                    ).format(self.vm.name, str(ex)),
-                )
-                return
-            dialog = Gtk.MessageDialog(
-                None, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK_CANCEL
-            )
-            dialog.set_title("Error restarting qube")
-            dialog.set_markup(
-                f"The qube {self.vm.name} couldn't be shut down "
-                "normally. The following error occurred: \n"
-                f"<tt>{str(ex)}</tt>\n\n"
-                "Do you want to force shutdown? \n\n<b>Warning:</b> "
-                "this may cause unexpected issues in connected qubes."
-            )
-            dialog.connect("response", self.react_to_question)
-            GLib.idle_add(dialog.show)
-
+            self.show_shutdown_dialog(ex)
+        if self.give_up:
+            return
         try:
-            while self.vm.is_running():
-                if self.give_up:
-                    return
-                await asyncio.sleep(1)
             await asyncio.to_thread(self.vm.start)
         except exc.QubesException as ex:
             show_error(
                 _("Error restarting qube"),
                 _(
-                    "The following error occurred while attempting to restart"
-                    "qube {0}:\n{1}"
+                    "The following error occurred when restarting the qube "
+                    "during start stage: {0}:\n{1}"
                 ).format(self.vm.name, str(ex)),
             )
 
-    def react_to_question(self, widget, response):
-        asyncio.create_task(self.react_to_question_async(widget, response))
+    def react_to_question(self, widget, response, action):
+        asyncio.create_task(self.react_to_question_async(widget, response, action))
 
-    async def react_to_question_async(self, widget, response):
-        if response == Gtk.ResponseType.OK:
-            try:
-                await asyncio.to_thread(self.vm.shutdown, force=True, wait=True)
-            except exc.QubesException as ex:
-                show_error(
-                    _("Error shutting down qube"),
-                    _(
-                        "The following error occurred while attempting to "
-                        "shut down qube {0}:\n{1}"
-                    ).format(self.vm.name, str(ex)),
-                )
-                self.give_up = True
-        else:
+    async def react_to_question_async(self, widget, response, action):
+        if response not in (Gtk.ResponseType.OK, Gtk.ResponseType.YES):
+            self.give_up = True
+            widget.destroy()
+            return
+        try:
+            await self.shutdown_from_response(response, action)
+        except exc.QubesException as ex:
+            self.show_shutdown_dialog(ex)
             self.give_up = True
         widget.destroy()
 
@@ -554,7 +529,7 @@ class InternalInfoItem(Gtk.MenuItem):
 class StartedMenu(Gtk.Menu):
     """The sub-menu for a started domain"""
 
-    def __init__(self, vm, app, icon_cache):
+    def __init__(self, vm, app, icon_cache, shutdown_failed=False):
         super().__init__()
         self.vm = vm
         self.app = app
@@ -568,7 +543,17 @@ class StartedMenu(Gtk.Menu):
 
         self.add(PreferencesItem(self.vm, icon_cache))
         self.add(PauseItem(self.vm, icon_cache))
-        self.add(ShutdownItem(self.vm, icon_cache, force=app.shift_pressed))
+        self.add(
+            ShutdownItem(
+                self.vm,
+                icon_cache,
+                force=app.shift_pressed and not shutdown_failed,
+                follow_shift=not shutdown_failed,
+            )
+        )
+        if shutdown_failed:
+            self.add(ShutdownItem(self.vm, icon_cache, force=True, follow_shift=False))
+            self.add(KillItem(self.vm, icon_cache))
         if self.vm.klass != "DispVM" or not self.vm.auto_cleanup:
             self.add(RestartItem(self.vm, icon_cache, force=app.shift_pressed))
 
@@ -716,6 +701,7 @@ class DomainMenuItem(Gtk.MenuItem):
         self.vm = vm
         self.app = app
         self.icon_cache = icon_cache
+        self.shutdown_failed = False
         self.decorator = qui.decorators.DomainDecorator(vm)
 
         # Main horizontal box
@@ -773,7 +759,12 @@ class DomainMenuItem(Gtk.MenuItem):
                 is_preload=is_preload,
             )
         elif state == "Running":
-            submenu = StartedMenu(self.vm, self.app, self.icon_cache)
+            submenu = StartedMenu(
+                self.vm,
+                self.app,
+                self.icon_cache,
+                shutdown_failed=self.shutdown_failed,
+            )
         elif state == "Paused":
             submenu = PausedMenu(self.vm, self.icon_cache)
         else:
@@ -1190,6 +1181,11 @@ class DomainTray(Gtk.Application):
             except Exception:  # pylint: disable=broad-except
                 # it's a fragile DispVM
                 state = "Transient"
+
+        if event == "domain-shutdown-failed":
+            item.shutdown_failed = True
+        elif event in ("domain-start", "domain-pre-start", "domain-shutdown"):
+            item.shutdown_failed = False
 
         item.update_state(state)
 

--- a/rpm_spec/qubes-desktop-linux-manager.spec.in
+++ b/rpm_spec/qubes-desktop-linux-manager.spec.in
@@ -57,7 +57,7 @@ Requires:  python%{python3_pkgversion}-inotify
 Requires:  libappindicator-gtk3
 Requires:  python%{python3_pkgversion}-systemd
 Requires:  gtk3
-Requires:  python%{python3_pkgversion}-qubesadmin >= 4.3.19
+Requires:  python%{python3_pkgversion}-qubesadmin >= 4.3.33
 # FIXME: we need some way for applying updates from GUI VM
 #Requires:  qubes-mgmt-salt-dom0-update >= 4.0.5
 Requires:  qubes-artwork >= 4.1.5


### PR DESCRIPTION
Waiting for the server to send the result of the API calls, allows dealing with failures/exceptions:

- QubesVM.shutdown -> .shutdown(wait=True)
- QubesVM.run_service -> .run_service_for_stdio

It also does not block the widget from being opened again even if an action is still running. This allows, for example:

- To create disposable qube and attach device to it (which takes 10s), but not block the widget from opening
- To detach and shutdown disposable that is hanging, without hanging the widget

For qui/tray/domains.py, the "widget.destroy()" is called earlier, cause it's not needed after the response is received. Else it hangs until the "react_to_question" finishes.

For: https://github.com/QubesOS/qubes-issues/issues/10648
For: https://github.com/QubesOS/qubes-issues/issues/10651
For: https://github.com/QubesOS/qubes-issues/issues/10835
Requires: https://github.com/QubesOS/qubes-core-admin/pull/807
Requires: https://github.com/QubesOS/qubes-core-admin-client/pull/469