### PR TITLE
Revert "Updater: Enable qubesadmin caching"

### DIFF
--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=wrong-import-position,import-error
 import argparse
-import asyncio
 import logging
 import sys
 import time
@@ -24,18 +23,7 @@ import qui.updater.utils
 
 gi.require_version("Gtk", "3.0")  # isort:skip
 from gi.repository import Gtk, Gdk, Gio  # isort:skip
-
-try:
-    from gi.events import GLibEventLoopPolicy
-
-    asyncio.set_event_loop_policy(GLibEventLoopPolicy())
-except ImportError:
-    import gbulb
-
-    gbulb.install()
-
 from qubesadmin import Qubes
-import qubesadmin.events
 import qubesadmin.exc
 
 # using locale.gettext is necessary for Gtk.Builder translation support to work
@@ -76,8 +64,6 @@ class QubesUpdater(Gtk.Application):
         self.log = logging.getLogger("vm-update.agent.PackageManager")
         self.log.addHandler(log_handler)
         self.log.setLevel(self.cliargs.log)
-        dispatcher = qubesadmin.events.EventsDispatcher(qapp)
-        asyncio.ensure_future(dispatcher.listen_for_events())
 
     def do_activate(self, *_args, **_kwargs):
         if not self.primary:


### PR DESCRIPTION
There is no asyncio event loop running in the updater, so events are not
handled. This means caching is enabled without invalidating stale data -
not good.

While enabling caching may be a good idea, it needs to be done _after_
asyncio loop is added. So, revert it for now.

This reverts commit f827ba7bf6221f084c5a03b9991cee1fa54eb5fe.
