### PR TITLE
Import qubes code after gbulb

### DIFF
--- a/qui/clipboard.py
+++ b/qui/clipboard.py
@@ -38,8 +38,6 @@ import json
 import math
 import os
 import fcntl
-import qubesadmin
-import qubesadmin.events
 
 import gi
 
@@ -56,6 +54,9 @@ except ImportError:
     gbulb.install()
 
 import pyinotify
+
+import qubesadmin
+import qubesadmin.events
 
 import gettext
 

--- a/qui/devices/device_widget.py
+++ b/qui/devices/device_widget.py
@@ -30,15 +30,6 @@ import time
 
 import importlib.resources
 
-import qubesadmin
-import qubesadmin.exc
-import qubesadmin.events
-import qubesadmin.tests
-import qubesadmin.tests.mock_app
-
-import qui
-import qui.utils
-
 import gi
 
 gi.require_version("Gtk", "3.0")  # isort:skip
@@ -52,6 +43,15 @@ except ImportError:
     import gbulb
 
     gbulb.install()
+
+import qubesadmin
+import qubesadmin.exc
+import qubesadmin.events
+import qubesadmin.tests
+import qubesadmin.tests.mock_app
+
+import qui
+import qui.utils
 
 from qui.devices import backend
 from qui.devices import actionable_widgets

--- a/qui/tray/domains.py
+++ b/qui/tray/domains.py
@@ -15,12 +15,6 @@ import traceback
 import abc
 
 import gi  # isort:skip
-import qubesadmin
-import qubesadmin.events
-from qubesadmin import exc
-
-import qui.decorators
-import qui.utils
 
 gi.require_version("Gtk", "3.0")  # isort:skip
 from gi.repository import Gdk, Gio, Gtk, GLib, GdkPixbuf  # isort:skip
@@ -33,6 +27,13 @@ except ImportError:
     import gbulb
 
     gbulb.install()
+
+import qubesadmin
+import qubesadmin.events
+from qubesadmin import exc
+
+import qui.decorators
+import qui.utils
 
 import gettext
 

--- a/qui/tray/updates.py
+++ b/qui/tray/updates.py
@@ -13,12 +13,6 @@ import asyncio
 import sys
 import subprocess
 
-import qubesadmin
-import qubesadmin.events
-import qui.utils
-from qubesadmin import exc
-from qubes_config.widgets.utils import open_url_in_disposable
-
 import gi  # isort:skip
 
 gi.require_version("Gtk", "3.0")  # isort:skip
@@ -32,6 +26,12 @@ except ImportError:
     import gbulb
 
     gbulb.install()
+
+import qubesadmin
+import qubesadmin.events
+import qui.utils
+from qubesadmin import exc
+from qubes_config.widgets.utils import open_url_in_disposable
 
 import gettext
 

--- a/qui/updater/updater.py
+++ b/qui/updater/updater.py
@@ -9,6 +9,18 @@ import sys
 import importlib.resources
 import gi  # isort:skip
 
+gi.require_version("Gtk", "3.0")  # isort:skip
+from gi.repository import Gtk, Gdk, Gio  # isort:skip
+
+try:
+    from gi.events import GLibEventLoopPolicy
+
+    asyncio.set_event_loop_policy(GLibEventLoopPolicy())
+except ImportError:
+    import gbulb
+
+    gbulb.install()
+
 from qubes_config.widgets.gtk_utils import (
     load_icon,
     load_icon_at_gtk_size,
@@ -22,18 +34,6 @@ from qui.updater.updater_settings import Settings, OverriddenSettings
 from qui.updater.summary_page import SummaryPage
 from qui.updater.intro_page import IntroPage
 import qui.updater.utils
-
-gi.require_version("Gtk", "3.0")  # isort:skip
-from gi.repository import Gtk, Gdk, Gio  # isort:skip
-
-try:
-    from gi.events import GLibEventLoopPolicy
-
-    asyncio.set_event_loop_policy(GLibEventLoopPolicy())
-except ImportError:
-    import gbulb
-
-    gbulb.install()
 
 from qubesadmin import Qubes
 import qubesadmin.events


### PR DESCRIPTION
If qubesadmin.events is imported before gbulb, it leads to memory leaks. To maintain consistency in the import order, place qubes modules after gbulb is installed.

Fixes: https://github.com/qubesos/qubes-issues/issues/8442

---

Untested.