### PR TITLE
Global Config: accept special policy targets

### DIFF
--- a/qubes_config/global_config/rule_list_widgets.py
+++ b/qubes_config/global_config/rule_list_widgets.py
@@ -35,6 +35,8 @@ import gi
 
 import qubesadmin
 import qubesadmin.vm
+from qrexec.exc import PolicySyntaxError
+from qrexec.policy.parser import Target
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
@@ -92,6 +94,7 @@ class VMWidget(Gtk.Box):
         additional_widget: Gtk.Widget | None = None,
         filter_function: Callable[[qubesadmin.vm.QubesVM], bool] | None = None,
         change_callback: Callable | None = None,
+        allow_target_tokens: bool = False,
     ):
         """
         :param qapp: Qubes object
@@ -103,11 +106,14 @@ class VMWidget(Gtk.Box):
         :param additional_widget: additional widget to be packed after selector
         widget
         :param filter_function: function used to filter available vms
+        :param allow_target_tokens: accept valid qrexec target tokens entered
+         manually
         """
 
         super().__init__(orientation=Gtk.Orientation.HORIZONTAL)
         self.qapp = qapp
         self.selected_value = initial_value
+        self.allow_target_tokens = allow_target_tokens
         self.filter_function = (
             filter_function if filter_function else lambda x: str(x) != "dom0"
         )
@@ -162,30 +168,39 @@ class VMWidget(Gtk.Box):
 
     def is_changed(self) -> bool:
         """Return True if widget was changed from its initial state."""
-        new_value = self.model.get_selected()
+        new_value = self.get_selected()
         return str(self.selected_value) != str(new_value)
 
     def save(self):
         """Store changes in model; must be used before set_editable(False) if
         it's desired to see changes reflected in non-editable state"""
         # cannot set a VM to none
-        if not self.model.get_selected():
+        new_value = self.get_selected()
+        if not new_value:
             raise ValueError(
                 _("{name} is not a valid qube name.").format(
                     name=self.model.entry_box.get_text()
                 )
             )
-        new_value = str(self.model.get_selected())
-        self.selected_value = new_value
-        self.name_widget.set_token(new_value)
+        self.selected_value = str(new_value)
+        self.name_widget.set_token(self.selected_value)
 
     def get_selected(self):
         """Get currently selected value."""
+        typed_value = self.model.entry_box.get_text()
+        if self.allow_target_tokens and typed_value.startswith("@"):
+            try:
+                return Target(typed_value)
+            except PolicySyntaxError:
+                pass
         return self.model.get_selected()
 
     def revert_changes(self):
         """Roll back to last saved state."""
         self.model.select_value(self.selected_value)
+        if str(self.model.get_selected()) != str(self.selected_value):
+            self.combobox.set_active_id(None)
+            self.model.entry_box.set_text(self.selected_value)
 
     def hide_selectors(self):
         self.selectors_hidden = True
@@ -408,6 +423,7 @@ class RuleListBoxRow(Gtk.ListBoxRow):
             TARGET_CATEGORIES,
             self.rule.target,
             additional_widget=self._get_delete_button(),
+            allow_target_tokens=True,
         )
 
     def get_action_widget(self) -> ActionWidget:

--- a/qubes_config/global_config/rule_list_widgets.py
+++ b/qubes_config/global_config/rule_list_widgets.py
@@ -64,7 +64,7 @@ SOURCE_CATEGORIES_ADMIN: dict[Any | str | None, str] | None = {
 TARGET_CATEGORIES: dict[Any | str | None, str] | None = {
     "@anyvm": _("ALL QUBES"),
     "@adminvm": _("TYPE: ADMINVM"),
-    "@default": _("DEFAULT QUBE"),
+    "@default": _("Default Qube"),
     "@dispvm": _("Default Disposable Qube"),
     "@type:AppVM": _("TYPE: APP"),
     "@type:TemplateVM": _("TYPE: TEMPLATES"),
@@ -188,7 +188,9 @@ class VMWidget(Gtk.Box):
     def get_selected(self):
         """Get currently selected value."""
         typed_value = self.model.entry_box.get_text()
-        if self.allow_target_tokens and typed_value.startswith("@"):
+        if self.allow_target_tokens and (
+            typed_value.startswith("@") or typed_value in ("dom0", "*")
+        ):
             try:
                 return Target(typed_value)
             except PolicySyntaxError:

--- a/qubes_config/global_config/rule_list_widgets.py
+++ b/qubes_config/global_config/rule_list_widgets.py
@@ -61,6 +61,8 @@ SOURCE_CATEGORIES_ADMIN: dict[Any | str | None, str] | None = {
 
 TARGET_CATEGORIES: dict[Any | str | None, str] | None = {
     "@anyvm": _("ALL QUBES"),
+    "@adminvm": _("TYPE: ADMINVM"),
+    "@default": _("DEFAULT QUBE"),
     "@dispvm": _("Default Disposable Qube"),
     "@type:AppVM": _("TYPE: APP"),
     "@type:TemplateVM": _("TYPE: TEMPLATES"),

--- a/qubes_config/global_config/rule_list_widgets.py
+++ b/qubes_config/global_config/rule_list_widgets.py
@@ -189,7 +189,7 @@ class VMWidget(Gtk.Box):
         """Get currently selected value."""
         typed_value = self.model.entry_box.get_text()
         if self.allow_target_tokens and (
-            typed_value.startswith("@") or typed_value in ("dom0", "*")
+            typed_value.startswith("@") or typed_value == "*"
         ):
             try:
                 return Target(typed_value)

--- a/qubes_config/tests/test_rule_list_widgets.py
+++ b/qubes_config/tests/test_rule_list_widgets.py
@@ -213,6 +213,8 @@ def test_rule_row(test_qapp):
     (
         "@default",
         "@adminvm",
+        "dom0",
+        "*",
         "@tag:work",
         "@dispvm:test-vm",
         "@dispvm:@tag:work",

--- a/qubes_config/tests/test_rule_list_widgets.py
+++ b/qubes_config/tests/test_rule_list_widgets.py
@@ -21,6 +21,8 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
 from unittest.mock import Mock, patch
+
+import pytest
 from qrexec.policy.parser import Rule
 from ..global_config.policy_handler import PolicyHandler
 from ..global_config.policy_rules import RuleSimple, SimpleVerbDescription
@@ -206,26 +208,52 @@ def test_rule_row(test_qapp):
         )
 
 
-def test_rule_row_accepts_special_targets(test_qapp):
+@pytest.mark.parametrize(
+    "target",
+    (
+        "@default",
+        "@adminvm",
+        "@tag:work",
+        "@dispvm:test-vm",
+        "@dispvm:@tag:work",
+    ),
+)
+def test_rule_row_accepts_special_targets(test_qapp, target):
     mock_handler = Mock(spec=PolicyHandler)
     mock_handler.verify_new_rule.return_value = None
 
-    for target in ("@default", "@adminvm"):
-        rule = make_rule("test-blue", "test-red", "ask")
-        rule_row = RuleListBoxRow(
-            parent_handler=mock_handler, rule=rule, qapp=test_qapp
-        )
+    rule = make_rule("test-blue", "test-red", "ask")
+    rule_row = RuleListBoxRow(parent_handler=mock_handler, rule=rule, qapp=test_qapp)
 
-        rule_row.set_edit_mode(True)
-        rule_row.target_widget.model.select_value(target)
-        assert rule_row.target_widget.get_selected() == target
+    rule_row.set_edit_mode(True)
+    rule_row.target_widget.model.entry_box.set_text(target)
+    assert rule_row.target_widget.get_selected() == target
 
-        with patch.object(rule_row, "get_parent"):
-            assert rule_row.validate_and_save()
+    with patch.object(rule_row, "get_parent"):
+        assert rule_row.validate_and_save()
 
-        assert str(rule_row.rule.raw_rule) == str(
-            make_rule("test-blue", target, "ask").raw_rule
-        )
+    assert str(rule_row.rule.raw_rule) == str(
+        make_rule("test-blue", target, "ask").raw_rule
+    )
+
+    rule_row.set_edit_mode(True)
+    rule_row.target_widget.model.entry_box.set_text("@invalid")
+    rule_row.revert()
+    assert rule_row.target_widget.get_selected() == target
+
+
+def test_rule_row_rejects_invalid_target_token(test_qapp):
+    mock_handler = Mock(spec=PolicyHandler)
+    mock_handler.verify_new_rule.return_value = None
+    rule = make_rule("test-blue", "test-red", "ask")
+    rule_row = RuleListBoxRow(parent_handler=mock_handler, rule=rule, qapp=test_qapp)
+
+    rule_row.set_edit_mode(True)
+    rule_row.target_widget.model.entry_box.set_text("@invalid")
+
+    with patch("qubes_config.global_config.rule_list_widgets.show_error") as mock_error:
+        assert not rule_row.validate_and_save()
+        assert mock_error.called
 
 
 def test_rule_delete_new(test_qapp):

--- a/qubes_config/tests/test_rule_list_widgets.py
+++ b/qubes_config/tests/test_rule_list_widgets.py
@@ -206,6 +206,28 @@ def test_rule_row(test_qapp):
         )
 
 
+def test_rule_row_accepts_special_targets(test_qapp):
+    mock_handler = Mock(spec=PolicyHandler)
+    mock_handler.verify_new_rule.return_value = None
+
+    for target in ("@default", "@adminvm"):
+        rule = make_rule("test-blue", "test-red", "ask")
+        rule_row = RuleListBoxRow(
+            parent_handler=mock_handler, rule=rule, qapp=test_qapp
+        )
+
+        rule_row.set_edit_mode(True)
+        rule_row.target_widget.model.select_value(target)
+        assert rule_row.target_widget.get_selected() == target
+
+        with patch.object(rule_row, "get_parent"):
+            assert rule_row.validate_and_save()
+
+        assert str(rule_row.rule.raw_rule) == str(
+            make_rule("test-blue", target, "ask").raw_rule
+        )
+
+
 def test_rule_delete_new(test_qapp):
     mock_handler = Mock(spec=PolicyHandler)
     mock_handler.verify_new_rule.return_value = None

--- a/qubes_config/tests/test_rule_list_widgets.py
+++ b/qubes_config/tests/test_rule_list_widgets.py
@@ -213,7 +213,6 @@ def test_rule_row(test_qapp):
     (
         "@default",
         "@adminvm",
-        "dom0",
         "*",
         "@tag:work",
         "@dispvm:test-vm",


### PR DESCRIPTION
The target picker only recognized fixed entries in `TARGET_CATEGORIES`. This meant that valid qrexec target values could not be entered manually in Global Config.

Keep the common static targets in the selector and validate the additional target forms with qrexec's `Target` parser. The target field accepts `*` and parameterized forms such as `@tag:TAG`, `@dispvm:VMNAME`, and `@dispvm:@tag:TAG`; invalid values are still rejected. AdminVM is exposed through the canonical `@adminvm` spelling rather than the legacy `dom0` alias.

Fixes QubesOS/qubes-issues#11031

Tests:
- `xvfb-run -a python3 -m pytest -q qubes_config/tests/test_rule_list_widgets.py` (18 passed)
- `black --check qubes_config/global_config/rule_list_widgets.py qubes_config/tests/test_rule_list_widgets.py`
- `git diff --check`
- `python3 -m py_compile qubes_config/global_config/rule_list_widgets.py qubes_config/tests/test_rule_list_widgets.py`